### PR TITLE
refactor: touch up some ai generated code

### DIFF
--- a/cli/bb-funcs/src/enriched.rs
+++ b/cli/bb-funcs/src/enriched.rs
@@ -8,7 +8,7 @@
 use std::collections::HashMap;
 use std::fmt::Write;
 
-use bb_arch::display::{param_abi_to_json, return_abi_to_json};
+use bb_arch::ToJson as AbiToJson;
 use bb_clang::display::{format_abi_param, format_return_location, format_tags};
 use bb_clang::{Constant, Function, Param, SourceLocation, ToJson};
 use bb_cli::terminal_width;
@@ -438,7 +438,7 @@ pub fn function_to_enriched_json(f: &Function, const_lookup: Option<&ConstantLoo
             // Replace raw abi_location with the enriched format.
             obj.remove("abi_location");
             obj.insert("index".into(), json!(i));
-            obj.insert("abi".into(), param_abi_to_json(p.get_abi_location()));
+            obj.insert("abi".into(), p.get_abi_location().to_json());
 
             // Add sparse metadata (directions, known constant values).
             let pm = meta.and_then(|m| p.get_name().and_then(|n| m.params.get(n)));
@@ -459,10 +459,7 @@ pub fn function_to_enriched_json(f: &Function, const_lookup: Option<&ConstantLoo
     let mut fj = f.to_json();
     let obj = fj.as_object_mut().unwrap();
     obj.insert("params".into(), json!(params));
-    obj.insert(
-        "return_abi".into(),
-        return_abi_to_json(f.get_return_location()),
-    );
+    obj.insert("return_abi".into(), f.get_return_location().to_json());
 
     if let Some(m) = meta {
         let api = m.metadata.as_ref();

--- a/crates/bb-arch/src/display.rs
+++ b/crates/bb-arch/src/display.rs
@@ -1,12 +1,9 @@
 //! Display and serialization helpers for architecture types.
 
-use serde_json::json;
-
 use crate::Register;
-use crate::location::{MemoryOperand, ParamLocation, ReturnLocation};
 use crate::reg::{Arm32Gpr, Arm64Gpr, X64Gpr, X64Xmm, X86Gpr};
 
-/* ────────────────────────────── Register names ─────────────────────────── */
+/* ───────────────────────────── Register names ───────────────────────────── */
 
 /// Get the canonical display name for a register.
 #[must_use]
@@ -110,58 +107,5 @@ pub const fn register_name(reg: &Register) -> &'static str {
             Arm32Gpr::Lr => "LR",
             Arm32Gpr::Pc => "PC",
         },
-    }
-}
-
-/* ──────────────────────── ABI JSON serialization ────────────────────────── */
-
-/// Serialize a [`MemoryOperand`] to JSON.
-#[must_use]
-pub fn operand_to_json(op: &MemoryOperand) -> serde_json::Value {
-    match op {
-        MemoryOperand::Reg(r) => json!({
-            "kind": "reg",
-            "register": register_name(r),
-        }),
-        MemoryOperand::RegImm { base, offset } => json!({
-            "kind": "stack",
-            "base": register_name(base),
-            "offset": offset,
-        }),
-    }
-}
-
-/// Serialize a [`ParamLocation`] to JSON.
-#[must_use]
-pub fn param_abi_to_json(loc: &ParamLocation) -> serde_json::Value {
-    match loc {
-        ParamLocation::Direct { locations, size } => {
-            let mut obj = match locations.first() {
-                Some(op) => operand_to_json(op),
-                None => json!({ "kind": "?" }),
-            };
-            if let Some(map) = obj.as_object_mut() {
-                map.insert("size".into(), json!(size));
-            }
-            obj
-        }
-        ParamLocation::Indirect { pointer, size } => json!({
-            "kind": "indirect",
-            "pointer": operand_to_json(pointer),
-            "size": size,
-        }),
-    }
-}
-
-/// Serialize a [`ReturnLocation`] to JSON.
-#[must_use]
-pub fn return_abi_to_json(loc: &ReturnLocation) -> serde_json::Value {
-    match loc {
-        ReturnLocation::Void => json!({ "kind": "void" }),
-        ReturnLocation::Register(r) => json!({
-            "kind": "reg",
-            "register": register_name(r),
-        }),
-        ReturnLocation::Indirect => json!({ "kind": "indirect" }),
     }
 }

--- a/crates/bb-arch/src/json.rs
+++ b/crates/bb-arch/src/json.rs
@@ -1,0 +1,67 @@
+//! JSON serialization trait for bb-arch types.
+
+use serde_json::{Value, json};
+
+use crate::display::register_name;
+use crate::location::{MemoryOperand, ParamLocation, ReturnLocation};
+
+/* ────────────────────────────────── Trait ───────────────────────────────── */
+
+/// Convert a bb-arch type to a [`serde_json::Value`].
+pub trait ToJson {
+    /// Structured JSON serialization.
+    fn to_json(&self) -> Value;
+}
+
+/* ────────────────────────────────── Impls ───────────────────────────────── */
+
+impl ToJson for MemoryOperand {
+    fn to_json(&self) -> Value {
+        match self {
+            Self::Reg(r) => json!({
+                "kind": "reg",
+                "register": register_name(r),
+            }),
+            Self::RegImm { base, offset } => json!({
+                "kind": "stack",
+                "base": register_name(base),
+                "offset": offset,
+            }),
+        }
+    }
+}
+
+impl ToJson for ParamLocation {
+    fn to_json(&self) -> Value {
+        match self {
+            Self::Direct { locations, size } => {
+                let mut obj = match locations.first() {
+                    Some(op) => op.to_json(),
+                    None => json!({ "kind": "?" }),
+                };
+                if let Some(map) = obj.as_object_mut() {
+                    map.insert("size".into(), json!(size));
+                }
+                obj
+            }
+            Self::Indirect { pointer, size } => json!({
+                "kind": "indirect",
+                "pointer": pointer.to_json(),
+                "size": size,
+            }),
+        }
+    }
+}
+
+impl ToJson for ReturnLocation {
+    fn to_json(&self) -> Value {
+        match self {
+            Self::Void => json!({ "kind": "void" }),
+            Self::Register(r) => json!({
+                "kind": "reg",
+                "register": register_name(r),
+            }),
+            Self::Indirect => json!({ "kind": "indirect" }),
+        }
+    }
+}

--- a/crates/bb-arch/src/lib.rs
+++ b/crates/bb-arch/src/lib.rs
@@ -4,12 +4,14 @@
 //! hardware registers, and where values live at the ABI level.
 
 pub mod display;
+pub mod json;
 pub mod location;
 pub mod reg;
 
 use serde::Serialize;
 use thiserror::Error;
 
+pub use json::ToJson;
 pub use location::{MemoryOperand, ParamLocation, ReturnLocation};
 pub use reg::Register;
 

--- a/crates/bb-clang/src/constant/macro_.rs
+++ b/crates/bb-clang/src/constant/macro_.rs
@@ -174,7 +174,7 @@ impl<'a> Constant<'a> {
             .map_err(|_| ConstantError::NotEvaluable)?;
 
         let value = ConstValue::from_cexpr(result).ok_or(ConstantError::NotEvaluable)?;
-        let location = SourceLocation::from_entity(&entity);
+        let location = SourceLocation::try_from(&entity).ok();
 
         let components: Vec<String> = component_constants
             .iter()

--- a/crates/bb-clang/src/constant/mod.rs
+++ b/crates/bb-clang/src/constant/mod.rs
@@ -178,7 +178,7 @@ impl<'a> TryFrom<Entity<'a>> for Constant<'a> {
         let kind = entity.get_kind();
         let name = entity.get_name().ok_or(ConstantError::NoName)?;
         let type_name = entity.get_type().map(|t| t.get_display_name());
-        let location = SourceLocation::from_entity(&entity);
+        let location = SourceLocation::try_from(&entity).ok();
 
         let (value, expression, body_tokens) = match kind {
             EntityKind::EnumConstantDecl => {

--- a/crates/bb-clang/src/enum_.rs
+++ b/crates/bb-clang/src/enum_.rs
@@ -126,7 +126,7 @@ impl<'a> TryFrom<Entity<'a>> for Enum<'a> {
 
         let constants = collect_enum_constants(&entity);
 
-        let location = SourceLocation::from_entity(&entity);
+        let location = SourceLocation::try_from(&entity).ok();
 
         Ok(Self {
             entity,

--- a/crates/bb-clang/src/error.rs
+++ b/crates/bb-clang/src/error.rs
@@ -3,6 +3,12 @@
 use clang::EntityKind;
 use thiserror::Error;
 
+/* ────────────────────────────────── Types ───────────────────────────────── */
+
+#[derive(Debug, Error)]
+#[error("Entity does not have a source location")]
+pub struct SourceLocationError;
+
 #[derive(Debug, Error)]
 pub enum StructError {
     #[error("Entity is neither a struct or class: {0:?}")]
@@ -81,6 +87,8 @@ pub enum ParamError {
 
 #[derive(Debug, Error)]
 pub enum Error {
+    #[error("SourceLocation error: {0}")]
+    SourceLocation(#[from] SourceLocationError),
     #[error("Struct error: {0}")]
     Struct(#[from] StructError),
     #[error("Field error: {0}")]

--- a/crates/bb-clang/src/function/abi.rs
+++ b/crates/bb-clang/src/function/abi.rs
@@ -51,7 +51,7 @@ pub enum CallConv {
     /// - On ARM32/ARM64: WIP
     Cdecl,
 
-    /* ───────────────────── x86 — may I never see you again ──────────────────── */
+    /* ─────────────────────────────────── x86 ────────────────────────────────── */
     /// - On x86:
     ///     - First two arguments that fit in a DWORD (left-to-right) are passed in `ECX` and `EDX` respectively.
     ///     - Arguments larger than DWORD skip register assignment.
@@ -66,26 +66,6 @@ pub enum CallConv {
     ///     - Returns integer in `EAX`.
     Stdcall,
 }
-
-/* ─────────────────────────────── Conversions ────────────────────────────── */
-
-impl<'a> TryFrom<&Type<'a>> for CallConv {
-    type Error = FunctionError;
-
-    fn try_from(type_: &Type<'a>) -> Result<Self, Self::Error> {
-        let cc = type_
-            .get_calling_convention()
-            .ok_or(FunctionError::NoCallingConvention)?;
-        match cc {
-            clang::CallingConvention::Cdecl => Ok(Self::Cdecl),
-            clang::CallingConvention::Stdcall => Ok(Self::Stdcall),
-            clang::CallingConvention::Fastcall => Ok(Self::Fastcall),
-            _ => Err(FunctionError::NoCallingConvention),
-        }
-    }
-}
-
-/* ──────────────────────── Parameter assignment ─────────────────────────── */
 
 impl CallConv {
     /// Assign ABI locations to each parameter based on architecture and
@@ -115,6 +95,35 @@ impl CallConv {
             Arch::Amd64 => return_location_x64(return_type),
             Arch::X86 => ReturnLocation::Register(Register::X86Gpr(X86Gpr::Eax)),
             Arch::Arm64 | Arch::Arm => todo!("ARM return location"),
+        }
+    }
+}
+
+enum X64ParamClass {
+    /// Passed in a GPR (or on stack as 8-byte slot).
+    Integer,
+    /// Passed in an XMM register (or on stack as 8-byte slot).
+    Float,
+    /// Small aggregate (1/2/4/8 bytes) — treated like integer.
+    Aggregate,
+    /// Large aggregate — passed by pointer (indirect).
+    IndirectAggregate(usize),
+}
+
+/* ─────────────────────────────── Conversions ────────────────────────────── */
+
+impl<'a> TryFrom<&Type<'a>> for CallConv {
+    type Error = FunctionError;
+
+    fn try_from(type_: &Type<'a>) -> Result<Self, Self::Error> {
+        let cc = type_
+            .get_calling_convention()
+            .ok_or(FunctionError::NoCallingConvention)?;
+        match cc {
+            clang::CallingConvention::Cdecl => Ok(Self::Cdecl),
+            clang::CallingConvention::Stdcall => Ok(Self::Stdcall),
+            clang::CallingConvention::Fastcall => Ok(Self::Fastcall),
+            _ => Err(FunctionError::NoCallingConvention),
         }
     }
 }
@@ -190,18 +199,7 @@ fn x64_param_class(ty: &Type<'_>) -> X64ParamClass {
     }
 }
 
-enum X64ParamClass {
-    /// Passed in a GPR (or on stack as 8-byte slot).
-    Integer,
-    /// Passed in an XMM register (or on stack as 8-byte slot).
-    Float,
-    /// Small aggregate (1/2/4/8 bytes) — treated like integer.
-    Aggregate,
-    /// Large aggregate — passed by pointer (indirect).
-    IndirectAggregate(usize),
-}
-
-/* ─────────────────── Microsoft x64 calling convention ──────────────────── */
+/* ────────────── Resolve parameter ABI for calling conventions ───────────── */
 
 fn assign_x64_microsoft(param_types: &[Type<'_>]) -> Vec<ParamLocation> {
     // Stack offsets are relative to RSP at callee entry (after CALL pushed
@@ -267,8 +265,6 @@ fn assign_x64_microsoft(param_types: &[Type<'_>]) -> Vec<ParamLocation> {
         .collect()
 }
 
-/* ─────────────────────────── x86 cdecl ─────────────────────────────────── */
-
 fn assign_x86_cdecl(param_types: &[Type<'_>]) -> Vec<ParamLocation> {
     // Stack offsets are relative to ESP at callee entry (after CALL pushed
     // the return address, before any prologue instructions execute).
@@ -295,14 +291,10 @@ fn assign_x86_cdecl(param_types: &[Type<'_>]) -> Vec<ParamLocation> {
         .collect()
 }
 
-/* ─────────────────────────── x86 stdcall ───────────────────────────────── */
-
+// Same layout as cdecl — only difference is cleanup responsibility.
 fn assign_x86_stdcall(param_types: &[Type<'_>]) -> Vec<ParamLocation> {
-    // Same layout as cdecl — only difference is cleanup responsibility.
     assign_x86_cdecl(param_types)
 }
-
-/* ─────────────────────────── x86 fastcall ──────────────────────────────── */
 
 fn assign_x86_fastcall(param_types: &[Type<'_>]) -> Vec<ParamLocation> {
     // Stack offsets are relative to ESP at callee entry (see assign_x86_cdecl).
@@ -340,7 +332,7 @@ fn assign_x86_fastcall(param_types: &[Type<'_>]) -> Vec<ParamLocation> {
         .collect()
 }
 
-/* ─────────────────────── x64 return location ───────────────────────────── */
+/* ─────────────────────────── x64 return location ────────────────────────── */
 
 fn return_location_x64(return_type: &Type<'_>) -> ReturnLocation {
     if is_float(return_type) {

--- a/crates/bb-clang/src/function/mod.rs
+++ b/crates/bb-clang/src/function/mod.rs
@@ -131,7 +131,7 @@ impl<'a> TryFrom<Entity<'a>> for Function<'a> {
         let return_type = type_.get_result_type().ok_or(FunctionError::NoReturnType)?;
         let return_type_name = return_type.get_display_name();
         let calling_convention = CallConv::try_from(&type_)?;
-        let location = SourceLocation::from_entity(&entity);
+        let location = SourceLocation::try_from(&entity).ok();
 
         // Compute return location.
         let return_location = calling_convention.return_location(arch, &return_type);

--- a/crates/bb-clang/src/function/param.rs
+++ b/crates/bb-clang/src/function/param.rs
@@ -111,7 +111,7 @@ impl<'a> TryFrom<Entity<'a>> for Param<'a> {
         let name = entity.get_name();
         let type_ = entity.get_type().ok_or(ParamError::NoType)?;
         let type_name = type_.get_display_name();
-        let location = SourceLocation::from_entity(&entity);
+        let location = SourceLocation::try_from(&entity).ok();
 
         let mut type_info = TypeInfo::from(type_);
         type_info.suppress_underlying_if_matches(Some(&type_name));

--- a/crates/bb-clang/src/json.rs
+++ b/crates/bb-clang/src/json.rs
@@ -105,6 +105,7 @@ impl ToJson for Struct<'_> {
     }
 }
 
+/// Universally handle references.
 impl<T: ToJson> ToJson for &T {
     fn to_json(&self) -> Value {
         (*self).to_json()
@@ -116,11 +117,6 @@ impl<T: ToJson> ToJson for &T {
 }
 
 /* ───────────────────────────────── Slices ───────────────────────────────── */
-
-/// Helper: map each element's `to_json` into a JSON array.
-fn slice_to_json<T: ToJson>(slice: &[T]) -> Value {
-    Value::Array(slice.iter().map(T::to_json).collect())
-}
 
 impl ToJson for [Constant<'_>] {
     fn to_json(&self) -> Value {
@@ -146,21 +142,13 @@ impl ToJson for [Constant<'_>] {
     }
 }
 
-impl ToJson for [&Constant<'_>] {
-    fn to_json(&self) -> Value {
-        slice_to_json(self)
-    }
-}
-
 impl ToJson for [Enum<'_>] {
     fn to_json(&self) -> Value {
         slice_to_json(self)
     }
-}
 
-impl ToJson for [&Enum<'_>] {
-    fn to_json(&self) -> Value {
-        slice_to_json(self)
+    fn to_json_full(&self) -> Value {
+        slice_to_json_full(self)
     }
 }
 
@@ -168,11 +156,9 @@ impl ToJson for [Field<'_>] {
     fn to_json(&self) -> Value {
         slice_to_json(self)
     }
-}
 
-impl ToJson for [&Field<'_>] {
-    fn to_json(&self) -> Value {
-        slice_to_json(self)
+    fn to_json_full(&self) -> Value {
+        slice_to_json_full(self)
     }
 }
 
@@ -180,11 +166,9 @@ impl ToJson for [Function<'_>] {
     fn to_json(&self) -> Value {
         slice_to_json(self)
     }
-}
 
-impl ToJson for [&Function<'_>] {
-    fn to_json(&self) -> Value {
-        slice_to_json(self)
+    fn to_json_full(&self) -> Value {
+        slice_to_json_full(self)
     }
 }
 
@@ -192,17 +176,9 @@ impl ToJson for [Param<'_>] {
     fn to_json(&self) -> Value {
         slice_to_json(self)
     }
-}
 
-impl ToJson for [&Param<'_>] {
-    fn to_json(&self) -> Value {
-        slice_to_json(self)
-    }
-}
-
-impl ToJson for [&Struct<'_>] {
-    fn to_json(&self) -> Value {
-        slice_to_json(self)
+    fn to_json_full(&self) -> Value {
+        slice_to_json_full(self)
     }
 }
 
@@ -239,6 +215,17 @@ impl ToJson for [Struct<'_>] {
     }
 }
 
+/// Universally handle slices of references.
+impl<T: ToJson> ToJson for [&T] {
+    fn to_json(&self) -> Value {
+        slice_to_json(self)
+    }
+
+    fn to_json_full(&self) -> Value {
+        slice_to_json_full(self)
+    }
+}
+
 /* ────────────────────────────────── Vecs ────────────────────────────────── */
 
 impl<T: ToJson> ToJson for Vec<T>
@@ -252,6 +239,18 @@ where
     fn to_json_full(&self) -> Value {
         self.as_slice().to_json_full()
     }
+}
+
+/* ───────────────────────────────── Helpers ──────────────────────────────── */
+
+/// Helper: map each element's `T::to_json` into a JSON array.
+fn slice_to_json<T: ToJson>(slice: &[T]) -> Value {
+    Value::Array(slice.iter().map(T::to_json).collect())
+}
+
+/// Helper: map each element's `T::to_json` into a JSON array.
+fn slice_to_json_full<T: ToJson>(slice: &[T]) -> Value {
+    Value::Array(slice.iter().map(T::to_json_full).collect())
 }
 
 /* ──────────────────────────── Component helpers ─────────────────────────── */

--- a/crates/bb-clang/src/lib.rs
+++ b/crates/bb-clang/src/lib.rs
@@ -25,7 +25,9 @@ pub use constant::{
 };
 pub use display::render_constants;
 pub use enum_::Enum;
-pub use error::{ConstantError, EnumError, FieldError, FunctionError, StructError};
+pub use error::{
+    ConstantError, EnumError, FieldError, FunctionError, SourceLocationError, StructError,
+};
 pub use function::{CallConv, Function, Param};
 pub use json::{ToJson, build_referred_components, collect_component_constants};
 pub use location::{SourceLocation, entity_in_header};

--- a/crates/bb-clang/src/location.rs
+++ b/crates/bb-clang/src/location.rs
@@ -6,6 +6,8 @@ use std::path::{Path, PathBuf};
 use clang::Entity;
 use serde::Serialize;
 
+use crate::error::SourceLocationError;
+
 /* ────────────────────────────────── Types ───────────────────────────────── */
 
 /// Source location information (file, line, column).
@@ -21,24 +23,6 @@ pub struct SourceLocation {
 }
 
 impl SourceLocation {
-    /// Extract source location from a Clang [`Entity`].
-    #[must_use]
-    pub fn from_entity(entity: &Entity) -> Option<Self> {
-        entity.get_location().map(|loc| {
-            let file_loc = loc.get_file_location();
-            let full_path = file_loc.file.map(|f| f.get_path());
-            let file = full_path
-                .as_ref()
-                .and_then(|p| p.file_name().map(|n| n.to_string_lossy().into_owned()));
-            Self {
-                file,
-                full_path,
-                line: file_loc.line,
-                column: file_loc.column,
-            }
-        })
-    }
-
     /// Full filesystem path, if available.
     #[must_use]
     pub fn path(&self) -> Option<&Path> {
@@ -54,6 +38,28 @@ impl SourceLocation {
         self.full_path
             .as_ref()
             .is_some_and(|p| p.to_string_lossy().to_lowercase().ends_with(&filter))
+    }
+}
+
+/* ─────────────────────────────── Conversions ────────────────────────────── */
+
+/// Extract [`SourceLocation`] from a Clang [`Entity`].
+impl TryFrom<&Entity<'_>> for SourceLocation {
+    type Error = SourceLocationError;
+
+    fn try_from(entity: &Entity<'_>) -> Result<Self, Self::Error> {
+        let loc = entity.get_location().ok_or(SourceLocationError)?;
+        let file_loc = loc.get_file_location();
+        let full_path = file_loc.file.map(|f| f.get_path());
+        let file = full_path
+            .as_ref()
+            .and_then(|p| p.file_name().map(|n| n.to_string_lossy().into_owned()));
+        Ok(Self {
+            file,
+            full_path,
+            line: file_loc.line,
+            column: file_loc.column,
+        })
     }
 }
 

--- a/crates/bb-clang/src/struct_/field.rs
+++ b/crates/bb-clang/src/struct_/field.rs
@@ -117,24 +117,6 @@ impl<'a> Field<'a> {
     }
 }
 
-/* ──────────────────────────────── Utilities ─────────────────────────────── */
-
-/// Collects all field declarations from a struct/class entity.
-pub fn collect_fields<'a>(entity: &Entity<'a>) -> Vec<Field<'a>> {
-    use clang::EntityVisitResult;
-
-    let mut fields = Vec::new();
-    entity.visit_children(|child, _| {
-        if child.get_kind() == EntityKind::FieldDecl {
-            if let Ok(field) = Field::try_from((child, entity)) {
-                fields.push(field);
-            }
-        }
-        EntityVisitResult::Continue
-    });
-    fields
-}
-
 /* ─────────────────────────────── Conversions ────────────────────────────── */
 
 /// Generate [`Field`] from child-parent reference tuple, where the child is a [`EntityKind::FieldDecl`].
@@ -160,7 +142,7 @@ impl<'a> TryFrom<(Entity<'a>, &Entity<'a>)> for Field<'a> {
         let offset = parent_type
             .get_offsetof(&name)
             .map_err(|_| FieldError::NoOffset(name.clone()))?;
-        let location = SourceLocation::from_entity(&entity);
+        let location = SourceLocation::try_from(&entity).ok();
         let size = type_.get_sizeof().map_err(|_| FieldError::NoSize)?;
         let alignment = type_.get_alignof().map_err(|_| FieldError::NoAlignment)?;
 
@@ -177,4 +159,22 @@ impl<'a> TryFrom<(Entity<'a>, &Entity<'a>)> for Field<'a> {
             alignment,
         })
     }
+}
+
+/* ──────────────────────────────── Utilities ─────────────────────────────── */
+
+/// Collects all field declarations from a struct/class entity.
+pub fn collect_fields<'a>(entity: &Entity<'a>) -> Vec<Field<'a>> {
+    use clang::EntityVisitResult;
+
+    let mut fields = Vec::new();
+    entity.visit_children(|child, _| {
+        if child.get_kind() == EntityKind::FieldDecl {
+            if let Ok(field) = Field::try_from((child, entity)) {
+                fields.push(field);
+            }
+        }
+        EntityVisitResult::Continue
+    });
+    fields
 }

--- a/crates/bb-clang/src/struct_/mod.rs
+++ b/crates/bb-clang/src/struct_/mod.rs
@@ -118,9 +118,6 @@ impl<'a> Struct<'a> {
     /// * `seen` - Set of type names already processed (for global deduplication).
     /// * `max_depth` - Maximum recursion depth.
     /// * `current_depth` - Current recursion level.
-    ///
-    /// Note: Unlike `write_fields()`, we don't remove names from `seen` after processing
-    /// because we want each type to appear only once in the final result.
     fn collect_nested(
         &self,
         result: &mut Vec<Self>,
@@ -157,7 +154,7 @@ impl<'a> TryFrom<Entity<'a>> for Struct<'a> {
             return Err(StructError::NotStructOrClass(kind));
         }
 
-        let location = SourceLocation::from_entity(&entity);
+        let location = SourceLocation::try_from(&entity).ok();
 
         // Handle anonymous structures
         let is_anonymous = entity

--- a/crates/bb-clang/src/type_info.rs
+++ b/crates/bb-clang/src/type_info.rs
@@ -9,7 +9,7 @@ use serde::Serialize;
 
 use crate::ext::UnderlyingType;
 
-/* ────────────────────────────────── Type ───────────────────────────────── */
+/* ────────────────────────────────── Type ────────────────────────────────── */
 
 /// Extracted type metadata from a [`clang::Type`].
 ///
@@ -39,6 +39,40 @@ pub struct TypeInfo<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub array_size: Option<usize>,
 }
+
+impl<'a> TypeInfo<'a> {
+    /// Clear `underlying_type` if it matches the given display name.
+    ///
+    /// Used by [`Field`](crate::Field) and [`Param`](crate::Param) to avoid
+    /// redundant output when the underlying type is the same as the display type.
+    pub fn suppress_underlying_if_matches(&mut self, display_name: Option<&str>) {
+        if let Some(ref u) = self.underlying_type {
+            if display_name.is_some_and(|d| d == u) {
+                self.underlying_type = None;
+            }
+        }
+    }
+
+    /// The raw clang type.
+    #[must_use]
+    pub const fn get_type(&self) -> &Type<'a> {
+        &self.type_
+    }
+
+    /// The canonical (fully resolved typedef) form of this type.
+    #[must_use]
+    pub fn get_canonical_type(&self) -> Type<'a> {
+        self.type_.get_canonical_type()
+    }
+
+    /// The underlying type after resolving pointers and arrays.
+    #[must_use]
+    pub fn get_underlying_type(&self) -> Type<'a> {
+        self.type_.get_underlying_type()
+    }
+}
+
+/* ─────────────────────────────── Conversions ────────────────────────────── */
 
 impl<'a> From<Type<'a>> for TypeInfo<'a> {
     /// Extract type metadata from a clang type.
@@ -78,41 +112,13 @@ impl<'a> From<Type<'a>> for TypeInfo<'a> {
     }
 }
 
-impl<'a> TypeInfo<'a> {
-    /// Clear `underlying_type` if it matches the given display name.
-    ///
-    /// Used by [`Field`](crate::Field) and [`Param`](crate::Param) to avoid
-    /// redundant output when the underlying type is the same as the display type.
-    pub fn suppress_underlying_if_matches(&mut self, display_name: Option<&str>) {
-        if let Some(ref u) = self.underlying_type {
-            if display_name.is_some_and(|d| d == u) {
-                self.underlying_type = None;
-            }
-        }
-    }
+/* ───────────────────────────────── Helpers ──────────────────────────────── */
 
-    /// The raw clang type.
-    #[must_use]
-    pub const fn get_type(&self) -> &Type<'a> {
-        &self.type_
-    }
-
-    /// The canonical (fully resolved typedef) form of this type.
-    #[must_use]
-    pub fn get_canonical_type(&self) -> Type<'a> {
-        self.type_.get_canonical_type()
-    }
-
-    /// The underlying type after resolving pointers and arrays.
-    #[must_use]
-    pub fn get_underlying_type(&self) -> Type<'a> {
-        self.type_.get_underlying_type()
-    }
-}
-
-/* ─────────────────────────────── Helpers ──────────────────────────────── */
-
-/// Count pointer indirection depth. `int**` = 2, `int*` = 1, `int` = 0.
+/// Count pointer indirection depth.
+///
+/// - `int**` = 2
+/// - `int*` = 1
+/// - `int` = 0
 fn count_pointer_depth(canonical: &Type) -> usize {
     let mut depth = 0;
     let mut t = *canonical;
@@ -123,7 +129,8 @@ fn count_pointer_depth(canonical: &Type) -> usize {
     depth
 }
 
-/// Check if the canonical type is a function pointer (pointer to FunctionProto/FunctionNoProto).
+/// Check if the canonical type is a function pointer (pointer to
+/// [`TypeKind::FunctionPrototype`] or [`TypeKind::FunctionNoPrototype`]).
 fn is_func_ptr(canonical: &Type) -> bool {
     canonical.get_pointee_type().is_some_and(|pointee| {
         matches!(


### PR DESCRIPTION
## bb output comparison (post-refactor)

Compared freshly built bb-types, bb-consts, and bb-funcs (release) against the existing bb-viewer/data/ JSON across all datasets, architectures, and modes.

### Matrix

| Dataset | Arch | Mode | types | consts | funcs |
|---------|------|------|-------|--------|-------|
| winsdk | amd64 | user | OK | OK | OK |
| winsdk | x86 | user | OK | OK | OK |
| winsdk | arm | user | OK | OK | -- |
| winsdk | arm64 | user | OK | OK | -- |
| winsdk | amd64 | kernel | OK | OK | OK |
| winsdk | x86 | kernel | OK | OK | OK |
| winsdk | arm | kernel | OK | OK | -- |
| winsdk | arm64 | kernel | OK | OK | -- |
| phnt | amd64 | user | OK | OK | OK |
| phnt | x86 | user | OK | OK | OK |
| phnt | arm | user | WARN | OK | -- |
| phnt | arm64 | user | WARN | OK | -- |
| phnt | amd64 | kernel | OK | OK | OK |
| phnt | x86 | kernel | OK | OK | OK |
| phnt | arm | kernel | OK | OK | -- |
| phnt | arm64 | kernel | OK | OK | -- |

- **--** = skipped (ARM ABI not implemented in bb-funcs)
- **OK** = identical JSON (ignoring the "command" field which contains the exe path)
- **WARN** = +368 chars difference (see below)

### Results

**38/40 files: IDENTICAL** after normalizing the "command" field (exe path differs between the downloaded release and the local build).

**2/40 files: minor difference** -- phnt/arm/types.json and phnt/arm64/types.json differ by +368 chars. The diff is in anonymous struct type names where clang embeds the SDK include path:

```
old: struct (unnamed at C:\...\Include\10.0.26100.0\um\winnt.h:2822:5)
new: struct (unnamed at C:\...\include\10.0.26100.0\um\winnt.h:2822:5)
```

This is a **path casing difference** (Include vs include) in the SDK resolution, not a code regression. The old data was generated with a different SDK path format.

### Conclusion

No regressions from the TryFrom and bb-arch::ToJson trait refactoring.
