### PR TITLE
feat(bb-sparse): driver-docs support, uv build, dual lookup

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,12 +27,14 @@ jobs:
       - name: Set up MSVC environment
         uses: ilammy/msvc-dev-cmd@v1
 
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+
       - name: Initialize submodules
         run: .\update-submodules.ps1
         shell: pwsh
-
-      - name: Install sparse Python dependencies
-        run: py -3 -m pip install -r crates/bb-sparse/sparse/requirements.txt
 
       - name: Determine version and revision
         id: get_version

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,12 +25,14 @@ jobs:
       - name: Set up MSVC environment
         uses: ilammy/msvc-dev-cmd@v1
 
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+
       - name: Initialize submodules
         run: .\update-submodules.ps1
         shell: pwsh
-
-      - name: Install sparse Python dependencies
-        run: py -3 -m pip install -r crates/bb-sparse/sparse/requirements.txt
 
       - name: Rust Cache
         uses: swatinem/rust-cache@v2

--- a/.github/workflows/version-check.yml
+++ b/.github/workflows/version-check.yml
@@ -1,0 +1,78 @@
+name: Version bump check
+
+# Asserts that any PR targeting master bumps the workspace package version
+# in Cargo.toml beyond what's currently on master.
+
+on:
+  pull_request:
+    branches:
+      - master
+    paths:
+      - 'Cargo.toml'
+      - '.github/workflows/version-check.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  check-version:
+    name: Workspace version > master
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout PR head
+        uses: actions/checkout@v4
+        with:
+          # Need master too so we can diff against it.
+          fetch-depth: 0
+
+      - name: Read PR version
+        id: pr
+        run: |
+          set -euo pipefail
+          pr_version=$(grep -oE '^version *= *"[^"]+"' Cargo.toml | head -n1 | sed -E 's/^version *= *"([^"]+)"/\1/')
+          echo "pr_version=$pr_version" >> "$GITHUB_OUTPUT"
+          echo "PR version: $pr_version"
+
+      - name: Read master version
+        id: base
+        run: |
+          set -euo pipefail
+          git fetch origin master --depth=1
+          master_version=$(git show origin/master:Cargo.toml | grep -oE '^version *= *"[^"]+"' | head -n1 | sed -E 's/^version *= *"([^"]+)"/\1/')
+          echo "master_version=$master_version" >> "$GITHUB_OUTPUT"
+          echo "master version: $master_version"
+
+      - name: Compare versions
+        env:
+          PR_VERSION: ${{ steps.pr.outputs.pr_version }}
+          MASTER_VERSION: ${{ steps.base.outputs.master_version }}
+        run: |
+          set -euo pipefail
+          python3 - <<'PY'
+          import os, re, sys
+
+          def parse(v):
+              # Accept "X.Y.Z" and "X.Y.Z-pre". Compare core as (X, Y, Z) tuple
+              # of ints, then break ties via lexicographic pre-release: any
+              # pre-release sorts *below* the release (per semver).
+              m = re.fullmatch(r"(\d+)\.(\d+)\.(\d+)(?:-([0-9A-Za-z.\-]+))?", v.strip())
+              if not m:
+                  print(f"::error::Cannot parse version: {v!r}", file=sys.stderr)
+                  sys.exit(2)
+              x, y, z = int(m[1]), int(m[2]), int(m[3])
+              pre = m[4]
+              return (x, y, z, 0 if pre else 1, pre or "")
+
+          pr = os.environ["PR_VERSION"]
+          base = os.environ["MASTER_VERSION"]
+          pr_key, base_key = parse(pr), parse(base)
+
+          if pr_key > base_key:
+              print(f"OK: PR version {pr} > master {base}")
+              sys.exit(0)
+          if pr_key == base_key:
+              print(f"::error::PR version {pr} is the same as master ({base}). Bump the workspace.package.version in Cargo.toml.")
+              sys.exit(1)
+          print(f"::error::PR version {pr} is lower than master {base}. The workspace.package.version cannot regress.")
+          sys.exit(1)
+          PY

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,7 @@
 [submodule "crates/bb-sparse/sparse"]
 	path = crates/bb-sparse/sparse
 	url = https://github.com/cristeigabriela/sparse.git
+	branch = main
 [submodule "crates/bb-sdk/phnt"]
 	path = crates/bb-sdk/phnt
 	url = https://github.com/mrexodia/phnt-single-header.git

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,7 +53,7 @@ bb-arch ← bb-clang ← bb-sdk ← bb-cli
 
 ## Building
 
-Requires MSVC build tools, LLVM/Clang (libclang.dll >= 18.1), Python >= 3.9, Rust 2024 edition.
+Requires MSVC build tools, LLVM/Clang (libclang.dll >= 18.1), Rust 2024 edition, and [uv](https://docs.astral.sh/uv/) (preferred) or Python >= 3.10. `uv` is used by `crates/bb-sparse/sparse` to manage its Python deps; bb-sparse's build.rs falls back to plain `python` / `py -3` if `uv` isn't on PATH.
 
 ```powershell
 # On Windows, MSVC link.exe must be on PATH before Git's /usr/bin/link.exe
@@ -63,14 +63,15 @@ Requires MSVC build tools, LLVM/Clang (libclang.dll >= 18.1), Python >= 3.9, Rus
 cargo build --release
 ```
 
-The `bb-sparse` build.rs auto-generates MSDN metadata from the sparse submodule (Python required). The `bb-sdk` build.rs auto-generates phnt.h from the phnt submodule. Both cache results and skip regeneration when the submodule hasn't changed.
+The `bb-sparse` build.rs auto-generates MSDN metadata from the sparse submodule in **two passes** — one for the SDK dataset (`sdk-api`, user-mode Win32 APIs) and one for the driver dataset (`windows-driver-docs-ddi`, KMDF/UMDF + kernel DDIs). Each pass is cached independently against its own submodule HEAD; only the pass whose submodule moved is rebuilt. The `bb-sdk` build.rs auto-generates phnt.h from the phnt submodule.
 
 ### Environment variable overrides
 
 | Variable | Purpose |
 |----------|---------|
 | `BB_PHNT_HEADER` | Use a custom phnt.h instead of generating from submodule |
-| `BB_SPARSE_JSON` | Use a pre-generated sparse.json instead of running Python |
+| `BB_SPARSE_SDK_JSON` | Use a pre-generated `sdk-api.json` instead of running sparse in SDK mode (alias: `BB_SPARSE_JSON`) |
+| `BB_SPARSE_DRIVER_JSON` | Use a pre-generated `driver-docs.json` instead of running sparse in driver mode |
 
 ## Running tests
 
@@ -135,10 +136,10 @@ Files using trailing underscores (`struct_/`, `enum_/`, `macro_.rs`) follow the 
 
 | Path | Repo | Purpose |
 |------|------|---------|
-| `crates/bb-sparse/sparse` | cristeigabriela/sparse | MSDN API metadata generator |
+| `crates/bb-sparse/sparse` | cristeigabriela/sparse (tracks `main`) | MSDN API metadata generator — embeds both sdk-api and windows-driver-docs-ddi |
 | `crates/bb-sdk/phnt` | mrexodia/phnt-single-header | PHNT NT header generator |
 
-Both have nested submodules (sdk-api, systeminformer). Use `.\update-submodules.ps1` to manage them.
+`sparse` has two nested submodules (sdk-api, windows-driver-docs-ddi); `phnt` has one (systeminformer). Use `.\update-submodules.ps1` to manage them.
 
 ## Self-maintenance
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -111,7 +111,7 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bb-arch"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "clap",
  "serde",
@@ -121,7 +121,7 @@ dependencies = [
 
 [[package]]
 name = "bb-clang"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "bb-arch",
  "bb-shared",
@@ -135,7 +135,7 @@ dependencies = [
 
 [[package]]
 name = "bb-cli"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "bb-sdk",
@@ -147,7 +147,7 @@ dependencies = [
 
 [[package]]
 name = "bb-consts"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "bb-clang",
@@ -165,7 +165,7 @@ dependencies = [
 
 [[package]]
 name = "bb-consts-tui"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "bb-clang",
@@ -180,7 +180,7 @@ dependencies = [
 
 [[package]]
 name = "bb-funcs"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "bb-arch",
@@ -202,7 +202,7 @@ dependencies = [
 
 [[package]]
 name = "bb-sdk"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "bb-arch",
@@ -214,11 +214,11 @@ dependencies = [
 
 [[package]]
 name = "bb-shared"
-version = "0.2.1"
+version = "0.3.0"
 
 [[package]]
 name = "bb-sparse"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "flate2",
  "serde",
@@ -227,7 +227,7 @@ dependencies = [
 
 [[package]]
 name = "bb-sql"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "rusqlite",
@@ -237,7 +237,7 @@ dependencies = [
 
 [[package]]
 name = "bb-tests"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "bb-arch",
@@ -245,6 +245,7 @@ dependencies = [
  "bb-consts",
  "bb-funcs",
  "bb-sdk",
+ "bb-sparse",
  "bb-types",
  "clang",
  "serde_json",
@@ -253,7 +254,7 @@ dependencies = [
 
 [[package]]
 name = "bb-tui"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "ratatui",
@@ -261,7 +262,7 @@ dependencies = [
 
 [[package]]
 name = "bb-types"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "bb-clang",
@@ -278,7 +279,7 @@ dependencies = [
 
 [[package]]
 name = "bb-types-tui"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "bb-clang",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.2.1"
+version = "0.3.0"
 authors = ["Gabriela Cristei <cristei.g772@gmail.com>", "Testers and contributors"]
 description = "Windows through a detective's lens. Analyze and export types, constants, functions across architectures and SDKs."
 repository = "https://github.com/cristeigabriela/bb"

--- a/README.md
+++ b/README.md
@@ -199,6 +199,13 @@ bb-funcs --where "params > 3 AND return_type = 'BOOL'"
 bb-funcs --where "name LIKE '%File%' AND is_exported = true"
 ```
 
+**Filter kernel/driver functions by IRQL constraint:**
+
+```bash
+bb-funcs --mode kernel --name "Wdf*" --irql "<= DISPATCH_LEVEL"
+bb-funcs --mode kernel --irql PASSIVE_LEVEL
+```
+
 **Export as JSON or SQLite for your own tooling:**
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ On a Windows host, you will need the following:
 - Visual Studio 2019/2022 **Build Tools**
 - LLVM + Clang (**libclang.dll**) version **>=18.1**
 - Rust **2024 edition**
-- Python **>=3.9** (for submodule setup)
+- [**uv**](https://docs.astral.sh/uv/) (Python package + project manager — `winget install --id=astral-sh.uv -e`). Plain Python **>=3.10** also works as a fallback.
 
 Afterwards, you may produce the binaries by invoking the following command:
 
@@ -132,14 +132,15 @@ The project uses two submodules, managed by `update-submodules.ps1`:
 | Submodule | Purpose | Required for | Setup |
 | --- | --- | --- | --- |
 | **phnt** | PHNT NT header generation ([phnt-single-header](https://github.com/mrexodia/phnt-single-header)) | `--phnt` flag | `.\update-submodules.ps1 phnt` |
-| **sparse** | MSDN API metadata ([sparse](https://github.com/cristeigabriela/sparse)) | Enriched function views | `.\update-submodules.ps1 sparse` |
+| **sparse** | MSDN API metadata ([sparse](https://github.com/cristeigabriela/sparse)) — embeds **both** the SDK and driver datasets | Enriched function views | `.\update-submodules.ps1 sparse` |
 
 You can update them individually or all at once (`.\update-submodules.ps1`). Both support env var overrides for custom data:
 
 | Env var | What it does |
 | --- | --- |
 | `BB_PHNT_HEADER` | Use a custom `phnt.h` instead of generating from the submodule |
-| `BB_SPARSE_JSON` | Use a pre-generated `sparse.json` instead of running the Python tool |
+| `BB_SPARSE_SDK_JSON` | Use a pre-generated `sdk-api.json` instead of running sparse in SDK mode (alias: `BB_SPARSE_JSON`) |
+| `BB_SPARSE_DRIVER_JSON` | Use a pre-generated `driver-docs.json` instead of running sparse in driver mode |
 
 ### First commands
 
@@ -354,6 +355,6 @@ We use `bb-sdk` to discover (or gather) the SDK environment, then we generate a 
 
 From the translation unit, we lift the AST entities into `bb-clang` serializable objects, and we use the information that we expose there to develop the tools.
 
-For functions, `bb-clang` computes the full ABI layout: which register or stack slot each parameter occupies, per architecture and calling convention (cdecl, stdcall, fastcall). `bb-funcs` enriches this with MSDN metadata (DLL, lib, min Windows version) from [sparse](https://github.com/cristeigabriela/sparse) and cross-references known constant values for each parameter. SQL `WHERE` clause filtering is supported via `bb-sql`.
+For functions, `bb-clang` computes the full ABI layout: which register or stack slot each parameter occupies, per architecture and calling convention (cdecl, stdcall, fastcall). `bb-funcs` enriches this with MSDN metadata (DLL, lib, min Windows version, and — for kernel/WDF DDIs — IRQL constraints, KMDF/UMDF versions, etc.) from [sparse](https://github.com/cristeigabriela/sparse) and cross-references known constant values for each parameter. SQL `WHERE` clause filtering is supported via `bb-sql`.
 
 For macros specifically, `bb-consts` does a two-pass resolution: first pass evaluates simple literals and variables, second pass substitutes known constant names into unresolved macro token streams before re-evaluating. This handles things like `#define PROCESS_ALL_ACCESS (STANDARD_RIGHTS_REQUIRED | SYNCHRONIZE | 0xFFFF)`.

--- a/cli/bb-funcs/src/enriched.rs
+++ b/cli/bb-funcs/src/enriched.rs
@@ -13,24 +13,42 @@ use bb_clang::display::{format_abi_param, format_return_location, format_tags};
 use bb_clang::{Constant, Function, Param, SourceLocation, ToJson};
 use bb_cli::terminal_width;
 use bb_consts_lib::{ConstFilter, collect_constants, collect_enums};
-use bb_sparse::{FuncMetadata, ParamMetadata};
+use bb_sdk::SdkMode;
+use bb_sparse::{DriverMetadata, Entry, ParamMetadata};
 use colored::Colorize;
 use comfy_table::{Attribute, Cell, CellAlignment, ContentArrangement, Table, presets};
 use serde_json::{Value, json};
 
 /* ────────────────────────────────── Types ───────────────────────────────── */
 
-/// A [`Function`] enriched with optional sparse metadata.
+/// A [`Function`] enriched with an optional sparse-metadata entry.
 pub struct EnrichedFunction<'a> {
     pub function: &'a Function<'a>,
-    pub metadata: Option<&'static FuncMetadata>,
+    pub entry: Option<Entry<'static>>,
 }
 
 impl<'a> EnrichedFunction<'a> {
+    /// Resolve sparse metadata for `function`, preferring the dataset that
+    /// matches the active `SdkMode`. Kernel mode tries `lookup_driver` first
+    /// then falls back to `lookup_sdk`; user mode is reversed.
     #[must_use]
-    pub fn new_ref(function: &'a Function<'a>) -> Self {
-        let metadata = bb_sparse::lookup(function.get_name());
-        Self { function, metadata }
+    pub fn new_ref(function: &'a Function<'a>, mode: SdkMode) -> Self {
+        let name = function.get_name();
+        let entry = lookup_for_mode(name, mode);
+        Self { function, entry }
+    }
+}
+
+/// Mode-aware sparse lookup: prefer the dataset that matches the SDK mode,
+/// fall back to the other if the function isn't in the preferred one.
+fn lookup_for_mode(name: &str, mode: SdkMode) -> Option<Entry<'static>> {
+    match mode {
+        SdkMode::Kernel => bb_sparse::lookup_driver(name)
+            .map(Entry::Driver)
+            .or_else(|| bb_sparse::lookup_sdk(name).map(Entry::Sdk)),
+        SdkMode::User => bb_sparse::lookup_sdk(name)
+            .map(Entry::Sdk)
+            .or_else(|| bb_sparse::lookup_driver(name).map(Entry::Driver)),
     }
 }
 
@@ -95,21 +113,38 @@ pub fn build_constant_lookup_from_tu(tu: &clang::TranslationUnit) -> ConstantLoo
     lookup
 }
 
+/// Project a [`ConstantLookup`] down to a plain `name -> u64` map for
+/// IRQL resolution. The location info isn't needed there.
+#[must_use]
+pub fn numeric_const_lookup(lookup: &ConstantLookup) -> HashMap<String, u64> {
+    lookup
+        .iter()
+        .map(|(k, v)| (k.clone(), v.value))
+        .collect()
+}
+
 /* ─────────────────────── Full enriched detail view ─────────────────────── */
 
 /// Render the full enriched detail view for a function.
 #[must_use]
-pub fn render_enriched_detail(f: &Function, const_lookup: Option<&ConstantLookup>) -> String {
-    let ef = EnrichedFunction::new_ref(f);
-    let meta = ef.metadata;
+pub fn render_enriched_detail(
+    f: &Function,
+    mode: SdkMode,
+    const_lookup: Option<&ConstantLookup>,
+) -> String {
+    let ef = EnrichedFunction::new_ref(f, mode);
+    let entry = ef.entry;
     let mut out = String::new();
 
-    render_prototype(&mut out, f, meta);
-    render_header_tags(&mut out, f, meta);
+    render_prototype(&mut out, f, entry);
+    render_header_tags(&mut out, f, entry);
     render_abi_section(&mut out, f);
-    if let Some(meta) = meta {
-        render_arguments_section(&mut out, f, meta, const_lookup);
-        render_info_section(&mut out, meta);
+    if let Some(entry) = entry {
+        render_arguments_section(&mut out, f, entry, const_lookup);
+        render_info_section(&mut out, entry);
+        if let Some(drv) = entry.driver() {
+            render_driver_section(&mut out, drv);
+        }
     }
 
     out
@@ -118,9 +153,10 @@ pub fn render_enriched_detail(f: &Function, const_lookup: Option<&ConstantLookup
 /* ───────────────────────── Section renderers ────────────────────────────── */
 
 /// Tags line + variants.
-fn render_header_tags(out: &mut String, f: &Function, meta: Option<&FuncMetadata>) {
+fn render_header_tags(out: &mut String, f: &Function, entry: Option<Entry<'_>>) {
     let mut tags = format_tags(f);
-    if let Some(meta) = meta {
+    if let Some(entry) = entry {
+        let meta = entry.as_metadata();
         if let Some(dll) = meta.dll_display() {
             let lib = meta.lib_display().unwrap_or_else(|| "?".into());
             tags.push(format!("{dll} ({lib})"));
@@ -128,8 +164,8 @@ fn render_header_tags(out: &mut String, f: &Function, meta: Option<&FuncMetadata
     }
     let _ = writeln!(out, "  {}", tags.join("  ·  ").bright_black());
 
-    if let Some(meta) = meta {
-        if let Some(ref api) = meta.metadata {
+    if let Some(entry) = entry {
+        if let Some(api) = entry.as_metadata().api_metadata() {
             let names = api.names();
             if names.len() > 1 {
                 let _ = writeln!(
@@ -177,15 +213,16 @@ fn render_abi_section(out: &mut String, f: &Function) {
 fn render_arguments_section(
     out: &mut String,
     f: &Function,
-    meta: &FuncMetadata,
+    entry: Entry<'_>,
     const_lookup: Option<&ConstantLookup>,
 ) {
+    let params = entry.as_metadata().params();
     let params_with_values: Vec<_> = f
         .get_params()
         .iter()
         .filter_map(|p| {
             let name = p.get_name()?;
-            let pm = meta.params.get(name)?;
+            let pm = params.get(name)?;
             if pm.values.is_empty() {
                 return None;
             }
@@ -214,14 +251,17 @@ fn render_arguments_section(
     }
 }
 
-/// Info section: requirements + linkage.
-fn render_info_section(out: &mut String, meta: &FuncMetadata) {
+/// Info section: requirements + linkage (shared fields).
+fn render_info_section(out: &mut String, entry: Entry<'_>) {
+    let meta = entry.as_metadata();
+    let api_locations = meta
+        .api_metadata()
+        .map(bb_sparse::ApiMetadata::locations)
+        .unwrap_or_default();
+
     let has_info = meta.min_client_str().is_some()
         || meta.min_server_str().is_some()
-        || meta
-            .metadata
-            .as_ref()
-            .is_some_and(|a| a.locations().len() > 1);
+        || api_locations.len() > 1;
 
     if !has_info {
         return;
@@ -236,17 +276,51 @@ fn render_info_section(out: &mut String, meta: &FuncMetadata) {
     if let Some(s) = meta.min_server_str() {
         let _ = writeln!(out, "  {} {s}", "server:".dimmed());
     }
-    if let Some(ref api) = meta.metadata {
-        let locations = api.locations();
-        if locations.len() > 1 {
-            let _ = writeln!(out, "  {} {}", "also in:".dimmed(), locations.join(", "));
+    if api_locations.len() > 1 {
+        let _ = writeln!(
+            out,
+            "  {} {}",
+            "also in:".dimmed(),
+            api_locations.join(", ")
+        );
+    }
+}
+
+/// Driver section: IRQL + KMDF/UMDF + target-type + tech-root + include.
+/// Only invoked when `entry.driver()` is `Some`. Rows with no source data
+/// are skipped to avoid dead lines.
+fn render_driver_section(out: &mut String, drv: &DriverMetadata) {
+    let irql_line = drv.irql.as_ref().map(|c| match c.op.as_deref() {
+        Some(op) => format!("{op} {}", c.level),
+        None => c.level.clone(),
+    });
+
+    let rows: [(&str, Option<String>); 7] = [
+        ("irql:", irql_line),
+        ("kmdf:", drv.kmdf_ver_str().map(str::to_string)),
+        ("umdf:", drv.umdf_ver_str().map(str::to_string)),
+        ("target-type:", drv.target_type_str().map(str::to_string)),
+        ("tech-root:", drv.tech_root_str().map(str::to_string)),
+        ("include:", drv.include_header_str().map(str::to_string)),
+        ("kind:", drv.construct_type_str().map(str::to_string)),
+    ];
+
+    if rows.iter().all(|(_, v)| v.is_none()) {
+        return;
+    }
+
+    let _ = writeln!(out);
+    let _ = writeln!(out, "  {}", "Driver".white().bold().underline());
+    for (label, value) in rows {
+        if let Some(v) = value {
+            let _ = writeln!(out, "  {} {v}", label.dimmed());
         }
     }
 }
 
 /* ──────────────────────── C prototype rendering ────────────────────────── */
 
-fn render_prototype(out: &mut String, f: &Function, meta: Option<&FuncMetadata>) {
+fn render_prototype(out: &mut String, f: &Function, entry: Option<Entry<'_>>) {
     let ret = f.get_return_type_name().green();
     let name = f.get_name().cyan().bold();
 
@@ -271,7 +345,7 @@ fn render_prototype(out: &mut String, f: &Function, meta: Option<&FuncMetadata>)
 
     let sal_width = params
         .iter()
-        .map(|p| sal_for_param(p, meta).len())
+        .map(|p| sal_for_param(p, entry).len())
         .max()
         .unwrap_or(0);
     let type_width = params
@@ -282,7 +356,7 @@ fn render_prototype(out: &mut String, f: &Function, meta: Option<&FuncMetadata>)
 
     for (i, p) in params.iter().enumerate() {
         let is_last = i == params.len() - 1;
-        let sal = sal_for_param(p, meta);
+        let sal = sal_for_param(p, entry);
         let sal_styled = if sal.is_empty() {
             format!("{:>width$}", "", width = sal_width + 6)
         } else {
@@ -302,14 +376,14 @@ fn render_prototype(out: &mut String, f: &Function, meta: Option<&FuncMetadata>)
     let _ = writeln!(out, "  );");
 }
 
-fn sal_for_param(p: &Param, meta: Option<&FuncMetadata>) -> String {
-    let Some(meta) = meta else {
+fn sal_for_param(p: &Param, entry: Option<Entry<'_>>) -> String {
+    let Some(entry) = entry else {
         return String::new();
     };
     let Some(name) = p.get_name() else {
         return String::new();
     };
-    let Some(pm) = meta.params.get(name) else {
+    let Some(pm) = entry.as_metadata().params().get(name) else {
         return String::new();
     };
     let dirs = pm.direction_strings();
@@ -419,11 +493,29 @@ fn param_values_to_json(pm: &ParamMetadata, const_lookup: Option<&ConstantLookup
     Value::Object(obj)
 }
 
+/// JSON shape for a driver entry's extra fields.
+fn driver_to_json(drv: &DriverMetadata) -> Value {
+    json!({
+        "irql": drv.irql,
+        "irql_raw": drv.irql_raw_str(),
+        "kmdf_ver": drv.kmdf_ver_str(),
+        "umdf_ver": drv.umdf_ver_str(),
+        "target_type": drv.target_type_str(),
+        "tech_root": drv.tech_root_str(),
+        "include_header": drv.include_header_str(),
+        "construct_type": drv.construct_type_str(),
+    })
+}
+
 /// Serialize a single function to enriched JSON.
 #[must_use]
-pub fn function_to_enriched_json(f: &Function, const_lookup: Option<&ConstantLookup>) -> Value {
-    let ef = EnrichedFunction::new_ref(f);
-    let meta = ef.metadata;
+pub fn function_to_enriched_json(
+    f: &Function,
+    mode: SdkMode,
+    const_lookup: Option<&ConstantLookup>,
+) -> Value {
+    let ef = EnrichedFunction::new_ref(f, mode);
+    let entry = ef.entry;
 
     // Start from the base serde JSON for each param, then enrich with
     // sparse metadata and reformatted ABI info.
@@ -441,7 +533,7 @@ pub fn function_to_enriched_json(f: &Function, const_lookup: Option<&ConstantLoo
             obj.insert("abi".into(), p.get_abi_location().to_json());
 
             // Add sparse metadata (directions, known constant values).
-            let pm = meta.and_then(|m| p.get_name().and_then(|n| m.params.get(n)));
+            let pm = entry.and_then(|e| p.get_name().and_then(|n| e.as_metadata().params().get(n)));
             let dirs: Vec<String> = pm
                 .map(bb_sparse::ParamMetadata::direction_strings)
                 .unwrap_or_default();
@@ -461,19 +553,28 @@ pub fn function_to_enriched_json(f: &Function, const_lookup: Option<&ConstantLoo
     obj.insert("params".into(), json!(params));
     obj.insert("return_abi".into(), f.get_return_location().to_json());
 
-    if let Some(m) = meta {
-        let api = m.metadata.as_ref();
+    if let Some(entry) = entry {
+        let meta = entry.as_metadata();
+        let api = meta.api_metadata();
         obj.insert(
             "metadata".into(),
             json!({
-                "dll": m.dll_display(),
-                "lib": m.lib_display(),
-                "min_client": m.min_client_str(),
-                "min_server": m.min_server_str(),
+                "source": match entry.source() {
+                    bb_sparse::Source::Sdk => "sdk",
+                    bb_sparse::Source::Driver => "driver",
+                },
+                "dll": meta.dll_display(),
+                "lib": meta.lib_display(),
+                "min_client": meta.min_client_str(),
+                "min_server": meta.min_server_str(),
                 "variants": api.map(bb_sparse::ApiMetadata::names).unwrap_or_default(),
                 "locations": api.map(bb_sparse::ApiMetadata::locations).unwrap_or_default(),
             }),
         );
+
+        if let Some(drv) = entry.driver() {
+            obj.insert("driver".into(), driver_to_json(drv));
+        }
     }
 
     fj
@@ -483,12 +584,13 @@ pub fn function_to_enriched_json(f: &Function, const_lookup: Option<&ConstantLoo
 #[must_use]
 pub fn functions_to_enriched_json(
     funcs: &[Function],
+    mode: SdkMode,
     const_lookup: Option<&ConstantLookup>,
 ) -> Value {
     Value::Array(
         funcs
             .iter()
-            .map(|f| function_to_enriched_json(f, const_lookup))
+            .map(|f| function_to_enriched_json(f, mode, const_lookup))
             .collect(),
     )
 }

--- a/cli/bb-funcs/src/lib.rs
+++ b/cli/bb-funcs/src/lib.rs
@@ -35,6 +35,38 @@ pub fn collect_funcs_filtered<'a>(
     filter.post_filter(funcs)
 }
 
+/// Apply an [`bb_sparse::IrqlConstraint`] filter to a list of functions.
+///
+/// Keeps only functions whose `bb-sparse` driver entry carries an
+/// [`bb_sparse::IrqlConstraint`] that `matches` the filter under the given
+/// numeric IRQL lookup (typically projected from the macro-preprocessed
+/// `ConstantLookup` via [`enriched::numeric_const_lookup`]).
+///
+/// Special case: an `ANY` filter level keeps every function (including
+/// SDK-only entries that have no IRQL constraint).
+#[must_use]
+pub fn apply_irql_filter<'a>(
+    funcs: Vec<Function<'a>>,
+    filter: &bb_sparse::IrqlConstraint,
+    numeric_lookup: &std::collections::HashMap<String, u64>,
+) -> Vec<Function<'a>> {
+    if filter.level == "ANY" {
+        return funcs;
+    }
+    funcs
+        .into_iter()
+        .filter(|f| {
+            let Some(drv) = bb_sparse::lookup_driver(f.get_name()) else {
+                return false;
+            };
+            let Some(irql) = drv.irql.as_ref() else {
+                return false;
+            };
+            irql.matches(filter, numeric_lookup) == Some(true)
+        })
+        .collect()
+}
+
 /// Iterate over function declarations in a [`TranslationUnit`].
 pub fn iter_funcs<'a>(tu: &'a TranslationUnit<'a>) -> impl Iterator<Item = Entity<'a>> {
     tu.get_entity()
@@ -261,6 +293,11 @@ pub struct FuncFilter {
 
     // SQL `WHERE` clause (applied after all other filters).
     pub where_clause: Option<String>,
+
+    // IRQL constraint filter. Applied outside `post_filter` (in `main.rs`)
+    // because it needs the macro-preprocessed constant lookup to resolve
+    // PASSIVE_LEVEL/DISPATCH_LEVEL/etc. to numeric values.
+    pub irql_filter: Option<bb_sparse::IrqlConstraint>,
 
     // Limit (applied last, after sort).
     pub first: Option<usize>,

--- a/cli/bb-funcs/src/main.rs
+++ b/cli/bb-funcs/src/main.rs
@@ -6,11 +6,13 @@ use bb_clang::display::render_function_list;
 use bb_cli::{current_command_string, get_header_config, print_suggestions};
 use bb_funcs_lib::enriched::{
     ConstantLookup, build_constant_lookup_from_tu, function_to_enriched_json,
-    functions_to_enriched_json, render_enriched_detail,
+    functions_to_enriched_json, numeric_const_lookup, render_enriched_detail,
 };
 use bb_funcs_lib::{
-    FuncFilter, FuncSort, ParamCountFilter, SortDir, collect_funcs_filtered, iter_funcs,
+    FuncFilter, FuncSort, ParamCountFilter, SortDir, apply_irql_filter, collect_funcs_filtered,
+    iter_funcs,
 };
+use bb_sparse::IrqlConstraint;
 use bb_sql::export_json_to_sqlite;
 use clang::{Clang, Index};
 use clap::Parser;
@@ -123,6 +125,31 @@ struct Args {
 
     #[arg(long = "sqlite", help = "Export results to a SQLite database file")]
     sqlite: Option<PathBuf>,
+
+    #[arg(
+        long = "irql",
+        value_parser = parse_irql_arg,
+        long_help = "Filter functions by their documented IRQL constraint.\n\n\
+            Grammar: [<|<=|=|==|>=|>] LEVEL\n\
+            Levels:  PASSIVE_LEVEL, APC_LEVEL, DISPATCH_LEVEL, DPC_LEVEL,\n         \
+                     HIGH_LEVEL, IPI_LEVEL, DEVICE_LEVEL, DIRQL, ANY.\n\n\
+            Numeric comparisons (<, <=, >, >=) resolve symbolic levels via the\n\
+            macro-preprocessed kernel-mode TU (PASSIVE_LEVEL=0, DISPATCH_LEVEL=2,\n\
+            HIGH_LEVEL=31, ...). DEVICE_LEVEL and DIRQL don't have a single\n\
+            numeric value and are filtered out by numeric ops.\n\n\
+            Examples:\n  \
+            --irql PASSIVE_LEVEL           # exact match\n  \
+            --irql \"<= DISPATCH_LEVEL\"     # callable at or below dispatch\n  \
+            --irql ANY                     # disable filtering",
+        help = "Filter by IRQL (see --help for grammar). Implies --mode kernel."
+    )]
+    irql: Option<IrqlConstraint>,
+}
+
+/// `clap` value parser for `--irql`. Wraps `bb_sparse::irql::parse_constraint`
+/// in a closure that adapts the error type to `String` for clap's display.
+fn parse_irql_arg(s: &str) -> Result<IrqlConstraint, String> {
+    bb_sparse::irql::parse_constraint(s).map_err(|e| e.to_string())
 }
 
 fn main() -> Result<()> {
@@ -150,6 +177,7 @@ fn main() -> Result<()> {
         sort: args.sort,
         sort_dir: args.sort_dir,
         where_clause: args.where_clause.clone(),
+        irql_filter: args.irql.clone(),
         first: args.first,
     };
     let funcs = collect_funcs_filtered(&tu, &func_filter).map_err(|e| anyhow::anyhow!(e))?;
@@ -164,26 +192,41 @@ fn main() -> Result<()> {
         );
     }
 
-    // Build constant lookup if sparse data is available.
-    let const_lookup = if bb_sparse::is_available() {
+    // Build constant lookup if sparse data is available, OR if the user
+    // asked for `--irql` (it needs the same const lookup to resolve
+    // PASSIVE_LEVEL/DISPATCH_LEVEL/etc. to numeric values).
+    let const_lookup = if bb_sparse::is_available() || args.irql.is_some() {
         let tu_macro = config.parse(&index, true)?;
         Some(build_constant_lookup_from_tu(&tu_macro))
     } else {
         None
     };
 
+    // Apply IRQL filter (post-collection, since it needs the const lookup).
+    let funcs = if let Some(ref filter) = args.irql {
+        let numeric = const_lookup
+            .as_ref()
+            .map(numeric_const_lookup)
+            .unwrap_or_default();
+        apply_irql_filter(funcs, filter, &numeric)
+    } else {
+        funcs
+    };
+
     let detail = args.detail || funcs.len() == 1;
+
+    let mode = args.shared.mode;
 
     if let Some(ref path) = args.sqlite {
         let json_rows: Vec<Value> = funcs
             .iter()
-            .map(|f| function_to_enriched_json(f, const_lookup.as_ref()))
+            .map(|f| function_to_enriched_json(f, mode, const_lookup.as_ref()))
             .collect();
         export_json_to_sqlite(path, "functions", &json_rows)?;
     } else if args.json {
-        print_json(funcs.as_slice(), const_lookup.as_ref())?;
+        print_json(funcs.as_slice(), mode, const_lookup.as_ref())?;
     } else {
-        print_display(funcs.as_slice(), detail, const_lookup.as_ref());
+        print_display(funcs.as_slice(), detail, mode, const_lookup.as_ref());
     }
 
     Ok(())
@@ -191,10 +234,15 @@ fn main() -> Result<()> {
 
 /* ──────────────────────────────── Printing ──────────────────────────────── */
 
-fn print_display(funcs: &[Function], detail: bool, const_lookup: Option<&ConstantLookup>) {
+fn print_display(
+    funcs: &[Function],
+    detail: bool,
+    mode: bb_sdk::SdkMode,
+    const_lookup: Option<&ConstantLookup>,
+) {
     if detail {
         for (i, f) in funcs.iter().enumerate() {
-            print!("{}", render_enriched_detail(f, const_lookup));
+            print!("{}", render_enriched_detail(f, mode, const_lookup));
             if i < funcs.len() - 1 {
                 println!();
             }
@@ -204,10 +252,14 @@ fn print_display(funcs: &[Function], detail: bool, const_lookup: Option<&Constan
     }
 }
 
-fn print_json(funcs: &[Function], const_lookup: Option<&ConstantLookup>) -> Result<()> {
+fn print_json(
+    funcs: &[Function],
+    mode: bb_sdk::SdkMode,
+    const_lookup: Option<&ConstantLookup>,
+) -> Result<()> {
     let command = current_command_string();
     let mut output = serde_json::json!({
-        "functions": functions_to_enriched_json(funcs, const_lookup),
+        "functions": functions_to_enriched_json(funcs, mode, const_lookup),
     });
     output
         .as_object_mut()

--- a/crates/bb-clang/src/constant/macro_.rs
+++ b/crates/bb-clang/src/constant/macro_.rs
@@ -13,6 +13,7 @@ use std::collections::{HashMap, HashSet};
 use clang::token::{Token, TokenKind};
 use clang::{Entity, EntityKind, TranslationUnit};
 
+use super::safe_tokenize;
 use super::tokens::clang_to_cexpr_token;
 use crate::error::ConstantError;
 use crate::location::SourceLocation;
@@ -95,7 +96,10 @@ impl<'a> Constant<'a> {
             resolving.remove(&name);
             ConstantError::NotEvaluable
         })?;
-        let tokens = range.tokenize();
+        let tokens = safe_tokenize(&range).ok_or_else(|| {
+            resolving.remove(&name);
+            ConstantError::NotEvaluable
+        })?;
 
         // First token is the macro name itself.
         let mut cexpr_tokens = vec![clang_to_cexpr_token(&tokens[0])];

--- a/crates/bb-clang/src/constant/mod.rs
+++ b/crates/bb-clang/src/constant/mod.rs
@@ -11,6 +11,7 @@ mod value;
 pub use macro_::{TuEntityMap, build_tu_entity_map};
 pub use value::{ConstLookup, ConstValue};
 
+use clang::source::SourceRange;
 use clang::token::Token;
 use clang::token::TokenKind;
 use clang::{Entity, EntityKind};
@@ -204,7 +205,7 @@ impl<'a> TryFrom<Entity<'a>> for Constant<'a> {
                 }
 
                 let range = entity.get_range().ok_or(ConstantError::NotEvaluable)?;
-                let tokens = range.tokenize();
+                let tokens = safe_tokenize(&range).ok_or(ConstantError::NotEvaluable)?;
                 let body = extract_body_tokens(&tokens);
                 let cexpr_tokens: Vec<_> = tokens.iter().map(clang_to_cexpr_token).collect();
 
@@ -293,7 +294,7 @@ fn is_word_token(s: &str) -> bool {
 /// For var decls, skips everything up to and including `=`.
 fn extract_expression_from_entity(entity: &Entity) -> Option<String> {
     let range = entity.get_range()?;
-    let tokens = range.tokenize();
+    let tokens = safe_tokenize(&range)?;
     // Find the `=` separator and take everything after it.
     let eq_pos = tokens.iter().position(|t| t.get_spelling() == "=")?;
     let expr_tokens: Vec<_> = tokens[eq_pos + 1..]
@@ -313,6 +314,33 @@ fn extract_expression_from_entity(entity: &Entity) -> Option<String> {
         out.push_str(s);
     }
     Some(out)
+}
+
+/* ────────────────────────────── safe_tokenize ──────────────────────────── */
+
+/// Wrap [`SourceRange::tokenize`] to drop ranges where `clang_tokenize`
+/// returns zero tokens.
+///
+/// **Why:** clang-rs 2.0.0 reads uninitialized memory for the token array
+/// pointer when `clang_tokenize` writes `count == 0`. Rust 1.78+'s
+/// `slice::from_raw_parts` precondition check turns that into a
+/// non-unwinding abort (uncatchable by `catch_unwind`). The trigger we've
+/// seen in kernel-mode parses is *inverted* source ranges (`end.offset <
+/// start.offset`), produced by some synthesized/intrinsic declarations in
+/// `wdm.h` / `ntddk.h`. Detecting `end <= start` (within a single file)
+/// before calling `.tokenize()` avoids the bad branch entirely.
+///
+/// Returns `None` when the range is missing a file, spans multiple files,
+/// or is empty/inverted.
+pub(crate) fn safe_tokenize<'tu>(range: &SourceRange<'tu>) -> Option<Vec<Token<'tu>>> {
+    let start = range.get_start().get_file_location();
+    let end = range.get_end().get_file_location();
+    // Both endpoints must be in the same file, and the range must cover at
+    // least one character.
+    match (start.file, end.file) {
+        (Some(sf), Some(ef)) if sf == ef && end.offset > start.offset => Some(range.tokenize()),
+        _ => None,
+    }
 }
 
 /* ───────────────────────────── Type utilities ───────────────────────────── */

--- a/crates/bb-sparse/README.md
+++ b/crates/bb-sparse/README.md
@@ -47,22 +47,23 @@ To build without sparse data (faster builds, smaller binary), don't init the spa
 ## Usage
 
 ```rust
-// Look up metadata for a function — checks SDK first, then driver.
-if let Some(meta) = bb_sparse::lookup("CreateFileW") {
+use bb_sparse::{Entry, Metadata};
+
+// Combined lookup: returns an Entry tagged with its source. Use `as_metadata()`
+// to access shared fields without caring which dataset the entry came from.
+if let Some(entry) = bb_sparse::lookup("CreateFileW") {
+    let meta = entry.as_metadata();
     println!("DLL: {:?}", meta.dll_display());
     println!("Min client: {:?}", meta.min_client_str());
 
-    if let Some(pm) = meta.params.get("dwShareMode") {
+    if let Some(pm) = meta.params().get("dwShareMode") {
         println!("Directions: {:?}", pm.direction_strings());
         println!("Values: {:?}", pm.values);
     }
-}
 
-// Driver-only metadata (IRQL, KMDF/UMDF, target-type, ...) is gated behind
-// `.driver()`, which returns Some(...) only for entries from the driver
-// dataset.
-if let Some(meta) = bb_sparse::lookup("WdfCollectionAdd") {
-    if let Some(drv) = meta.driver() {
+    // Driver-only fields are accessible only when the entry is from the
+    // driver dataset.
+    if let Some(drv) = entry.driver() {
         if let Some(irql) = &drv.irql {
             println!("IRQL: {} {}", irql.op.as_deref().unwrap_or("="), irql.level);
         }
@@ -70,9 +71,17 @@ if let Some(meta) = bb_sparse::lookup("WdfCollectionAdd") {
     }
 }
 
-// Per-dataset queries.
-let sdk_only    = bb_sparse::lookup_sdk("CreateFileW");
-let driver_only = bb_sparse::lookup_driver("WdfCollectionAdd");
+// Typed per-dataset lookups give back concrete types directly.
+let sdk_only:    Option<&bb_sparse::SdkMetadata>    = bb_sparse::lookup_sdk("CreateFileW");
+let driver_only: Option<&bb_sparse::DriverMetadata> = bb_sparse::lookup_driver("WdfCollectionAdd");
+
+// Numeric IRQL comparisons (resolves PASSIVE_LEVEL etc. via your own
+// `HashMap<String, u64>` of kernel-mode constants — bb-funcs builds this
+// from a macro-preprocessed translation unit).
+let filter = bb_sparse::irql::parse_constraint("<= DISPATCH_LEVEL")?;
+let matches = driver_only
+    .and_then(|d| d.irql.as_ref())
+    .and_then(|c| c.matches(&filter, &irql_consts));
 
 // Availability + counts.
 if bb_sparse::is_available() {

--- a/crates/bb-sparse/README.md
+++ b/crates/bb-sparse/README.md
@@ -2,43 +2,52 @@
 
 > Embedded Windows API metadata from [sparse](https://github.com/cristeigabriela/sparse).
 
-`bb-sparse` provides offline lookup of function-level documentation metadata extracted from Microsoft's sdk-api repository: library/DLL info, version requirements, parameter directions (SAL), and known constant values.
+`bb-sparse` provides offline lookup of function-level documentation metadata extracted from MSDN: library/DLL info, version requirements, parameter directions (SAL), known constant values, and — for kernel/WDF DDIs — IRQL constraints, KMDF/UMDF version tags, `target-type`, `tech.root`, etc.
 
-The JSON data is gzip-compressed at build time (~38MB raw → ~1.6MB compressed) and decompressed lazily on first access.
+Two datasets are embedded:
+
+| Dataset | Source repo | Function namespace |
+| --- | --- | --- |
+| **SDK** | [MicrosoftDocs/sdk-api](https://github.com/MicrosoftDocs/sdk-api) | user-mode Win32 (`CreateFileW`, `RegOpenKeyExA`, …) |
+| **Driver** | [cristeigabriela/windows-driver-docs-ddi](https://github.com/cristeigabriela/windows-driver-docs-ddi) (fork pinned at `integration/all-open-prs`) | KMDF/UMDF + kernel DDIs (`WdfCollectionAdd`, `KeAcquireSpinLock`, …) |
+
+Both JSON blobs are gzip-compressed at build time and decompressed lazily on first access. SDK and driver entries share one lookup space — [`lookup`] tries SDK first then driver, since the namespaces are essentially disjoint.
 
 ---
 
 ## How it works
 
-The `build.rs` script handles data generation:
+The `build.rs` script handles data generation in two passes (one per dataset):
 
-1. **`BB_SPARSE_JSON` env var** — if set, uses a pre-generated JSON file directly.
-2. **`sparse.json` file** — if found next to the workspace root or crate, uses it.
-3. **Auto-generate** — runs the [sparse](https://github.com/cristeigabriela/sparse) Python tool against the sdk-api submodule:
-   - Initializes the `sparse/sdk-api` git submodule if needed (~1GB clone, first time only).
-   - Runs `sparse.py` to parse MSDN markdown files (~8s).
-   - Caches the result: subsequent builds are instant unless sdk-api is updated (tracked via git rev stamp).
+1. **Override env vars** — if set, points the build at a pre-generated JSON:
+   - `BB_SPARSE_SDK_JSON` (or legacy `BB_SPARSE_JSON`) for the SDK dataset
+   - `BB_SPARSE_DRIVER_JSON` for the driver dataset
+2. **Workspace-root drop-in** — if `sdk-api.json` and/or `driver-docs.json` exists at the workspace root, uses it.
+3. **Auto-generate** — runs the [sparse](https://github.com/cristeigabriela/sparse) Python tool against the relevant nested submodule:
+   - Initializes `sparse/sdk-api` and/or `sparse/windows-driver-docs-ddi` if missing (~1GB clone each, first time only).
+   - Prefers `uv run python sparse.py` (fast, hermetic — sparse ships a `pyproject.toml`); falls back to plain Python if `uv` isn't on PATH.
+   - Caches each dataset under its own stamp file: bb-sparse only regenerates the modes whose submodule HEAD actually moved.
 
-If none of the above succeed (no Python, no submodule, etc.), an empty placeholder is embedded and `bb_sparse::is_available()` returns `false`.
+If a given mode can't be generated (no submodule, no Python/uv, etc.) bb-sparse embeds an empty placeholder for that mode only. The other mode still works.
 
 ### Setup
-
-The recommended way:
 
 ```powershell
 .\update-submodules.ps1 sparse
 ```
 
+This initializes both nested submodules and runs `uv sync` so subsequent `cargo build` invocations don't need to fetch dependencies.
+
 ### Opting out
 
-To build without sparse data (faster builds, smaller binary), simply don't init the sparse submodule. The build.rs gracefully degrades: if the submodule or Python is missing, it embeds an empty placeholder. `bb-funcs` falls back to the plain ABI detail view.
+To build without sparse data (faster builds, smaller binary), don't init the sparse submodule. The `build.rs` falls back to empty placeholders and `bb_sparse::is_available()` returns `false`. You can also opt out of just one mode by leaving its nested submodule un-initialized.
 
 ---
 
 ## Usage
 
 ```rust
-// Look up metadata for a function.
+// Look up metadata for a function — checks SDK first, then driver.
 if let Some(meta) = bb_sparse::lookup("CreateFileW") {
     println!("DLL: {:?}", meta.dll_display());
     println!("Min client: {:?}", meta.min_client_str());
@@ -49,9 +58,29 @@ if let Some(meta) = bb_sparse::lookup("CreateFileW") {
     }
 }
 
-// Check if data is available.
+// Driver-only metadata (IRQL, KMDF/UMDF, target-type, ...) is gated behind
+// `.driver()`, which returns Some(...) only for entries from the driver
+// dataset.
+if let Some(meta) = bb_sparse::lookup("WdfCollectionAdd") {
+    if let Some(drv) = meta.driver() {
+        if let Some(irql) = &drv.irql {
+            println!("IRQL: {} {}", irql.op.as_deref().unwrap_or("="), irql.level);
+        }
+        println!("KMDF: {:?}", drv.kmdf_ver_str());
+    }
+}
+
+// Per-dataset queries.
+let sdk_only    = bb_sparse::lookup_sdk("CreateFileW");
+let driver_only = bb_sparse::lookup_driver("WdfCollectionAdd");
+
+// Availability + counts.
 if bb_sparse::is_available() {
-    println!("{} functions indexed", bb_sparse::entry_count());
+    println!(
+        "{} SDK + {} driver functions",
+        bb_sparse::entry_count_sdk(),
+        bb_sparse::entry_count_driver(),
+    );
 }
 ```
 
@@ -59,7 +88,7 @@ if bb_sparse::is_available() {
 
 ## Data schema
 
-Each function entry contains:
+Shared fields across both datasets:
 
 | Field | Type | Example |
 | --- | --- | --- |
@@ -70,7 +99,21 @@ Each function entry contains:
 | `min_server_version` | string | `"Windows Server 2003 [desktop apps only]"` |
 | `metadata.api_location` | array | `["Kernel32.dll", "KernelBase.dll", ...]` |
 | `metadata.api_name` | array | `["CreateFile", "CreateFileA", "CreateFileW"]` |
+| `metadata.description` | string | `"Creates or opens a file or I/O device. ..."` |
 | `params.<name>.directions` | array | `["in"]`, `["in", "optional"]` |
 | `params.<name>.values` | object | `{"FILE_SHARE_READ": 1, ...}` |
 
-All fields are nullable — the sparse JSON schema is inconsistent across entries. The types use `serde_json::Value` internally and expose typed accessor methods.
+Driver-only fields, exposed via `meta.driver()`:
+
+| Field | Type | Example |
+| --- | --- | --- |
+| `include_header` | string | `"wdf.h"` |
+| `target_type` | string | `"Universal"` |
+| `construct_type` | string | `"function"`, `"macro"`, `"method"` |
+| `kmdf_ver` | string | `"1.0"`, `"1.15"` |
+| `umdf_ver` | string | `"2.0"` |
+| `tech_root` | string | `"storage"`, `"audio"` |
+| `irql` | `{level, op}` or null | `{"level": "PASSIVE_LEVEL", "op": "<="}` |
+| `irql_raw` | string | original frontmatter text for unparseable entries |
+
+All fields are nullable — sparse's JSON schema is permissive — and the types use `serde_json::Value` internally with typed accessor methods.

--- a/crates/bb-sparse/build.rs
+++ b/crates/bb-sparse/build.rs
@@ -11,122 +11,230 @@ use flate2::write::GzEncoder;
 
 fn main() {
     println!("cargo::rerun-if-env-changed=BB_SPARSE_JSON");
+    println!("cargo::rerun-if-env-changed=BB_SPARSE_SDK_JSON");
+    println!("cargo::rerun-if-env-changed=BB_SPARSE_DRIVER_JSON");
 
     let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());
-    let gz_path = out_dir.join("sparse.json.gz");
-    let stamp_path = out_dir.join("sparse.stamp");
     let manifest_dir = PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap());
+    let sparse_dir = manifest_dir.join("sparse");
 
-    // 1. BB_SPARSE_JSON env var always wins (explicit pre-generated file).
-    if let Some(path) = env::var("BB_SPARSE_JSON")
-        .map(PathBuf::from)
-        .ok()
-        .filter(|p| p.exists())
-    {
+    build_mode(Mode::Sdk, &out_dir, &sparse_dir);
+    build_mode(Mode::Driver, &out_dir, &sparse_dir);
+}
+
+/* ───────────────────────────────── Modes ────────────────────────────────── */
+
+#[derive(Clone, Copy)]
+enum Mode {
+    Sdk,
+    Driver,
+}
+
+impl Mode {
+    fn gz_name(self) -> &'static str {
+        match self {
+            Self::Sdk => "sparse_sdk.json.gz",
+            Self::Driver => "sparse_driver.json.gz",
+        }
+    }
+
+    fn stamp_name(self) -> &'static str {
+        match self {
+            Self::Sdk => "sparse_sdk.stamp",
+            Self::Driver => "sparse_driver.stamp",
+        }
+    }
+
+    fn override_env(self) -> &'static [&'static str] {
+        match self {
+            // Legacy BB_SPARSE_JSON is honored for backwards compatibility
+            // (it pointed at the SDK-mode JSON, which was the only one
+            // bb-sparse used to embed).
+            Self::Sdk => &["BB_SPARSE_SDK_JSON", "BB_SPARSE_JSON"],
+            Self::Driver => &["BB_SPARSE_DRIVER_JSON"],
+        }
+    }
+
+    fn workspace_json_name(self) -> &'static str {
+        match self {
+            Self::Sdk => "sdk-api.json",
+            Self::Driver => "driver-docs.json",
+        }
+    }
+
+    fn submodule_subpath(self) -> &'static str {
+        match self {
+            Self::Sdk => "sdk-api",
+            Self::Driver => "windows-driver-docs-ddi",
+        }
+    }
+
+    fn content_subpath(self) -> &'static str {
+        match self {
+            Self::Sdk => "sdk-api/sdk-api-src/content",
+            Self::Driver => "windows-driver-docs-ddi/wdk-ddi-src/content",
+        }
+    }
+
+    fn sparse_mode_flag(self) -> &'static str {
+        match self {
+            Self::Sdk => "sdk",
+            Self::Driver => "driver",
+        }
+    }
+
+    fn label(self) -> &'static str {
+        match self {
+            Self::Sdk => "sdk",
+            Self::Driver => "driver",
+        }
+    }
+}
+
+/* ─────────────────────────── Per-mode pipeline ──────────────────────────── */
+
+fn build_mode(mode: Mode, out_dir: &Path, sparse_dir: &Path) {
+    let gz_path = out_dir.join(mode.gz_name());
+    let stamp_path = out_dir.join(mode.stamp_name());
+
+    // 1. Explicit override env vars always win.
+    for var in mode.override_env() {
+        if let Some(path) = env::var(var)
+            .map(PathBuf::from)
+            .ok()
+            .filter(|p| p.exists())
+        {
+            println!("cargo::rerun-if-changed={}", path.display());
+            compress_json(&path, &gz_path);
+            return;
+        }
+    }
+
+    // 2. Workspace-root or crate-root pre-generated file.
+    let pre_generated = find_workspace_root()
+        .map(|root| root.join(mode.workspace_json_name()))
+        .filter(|p| p.exists());
+
+    if let Some(path) = pre_generated {
         println!("cargo::rerun-if-changed={}", path.display());
         compress_json(&path, &gz_path);
         return;
     }
 
-    // 2. Check for pre-generated sparse.json next to workspace root or crate.
-    let pre_generated = find_workspace_root()
-        .map(|root| root.join("sparse.json"))
-        .filter(|p| p.exists())
-        .or_else(|| {
-            let p = manifest_dir.join("sparse.json");
-            p.exists().then_some(p)
-        });
-
-    if let Some(path) = &pre_generated {
-        println!("cargo::rerun-if-changed={}", path.display());
-        compress_json(path, &gz_path);
-        return;
-    }
-
-    // 3. Auto-generate from sparse submodule + sdk-api.
-    let sparse_dir = manifest_dir.join("sparse");
+    // 3. Auto-generate from sparse submodule.
     let sparse_py = sparse_dir.join("sparse.py");
-    let sdk_api_dir = sparse_dir.join("sdk-api");
-    let sdk_api_content = sdk_api_dir.join("sdk-api-src/content");
+    let content_dir = sparse_dir.join(mode.content_subpath());
 
     if !sparse_py.exists() {
         println!(
-            "cargo::warning=sparse submodule not found — embedding empty data. Run `git submodule update --init --recursive`"
+            "cargo::warning=sparse submodule not found — embedding empty {} data. Run `git submodule update --init --recursive`",
+            mode.label()
         );
         write_empty(&gz_path);
         return;
     }
 
-    // Initialize the nested sdk-api submodule if needed.
-    if !sdk_api_content.exists() {
-        eprintln!("bb-sparse: initializing sdk-api submodule (this may take a while)...");
+    let submodule_root = sparse_dir.join(mode.submodule_subpath());
+
+    // Initialize the relevant nested submodule if needed.
+    if !content_dir.exists() {
+        eprintln!(
+            "bb-sparse: initializing nested submodule {} (this may take a while)...",
+            mode.submodule_subpath()
+        );
         let status = Command::new("git")
-            .args(["submodule", "update", "--init", "--recursive"])
-            .current_dir(&sparse_dir)
+            .args(["submodule", "update", "--init", mode.submodule_subpath()])
+            .current_dir(sparse_dir)
             .status();
 
         match status {
             Ok(s) if s.success() => {}
             Ok(s) => {
                 println!(
-                    "cargo::warning=git submodule init failed (exit {s}) — embedding empty sparse data"
+                    "cargo::warning=git submodule init for {} failed (exit {s}) — embedding empty data",
+                    mode.label()
                 );
                 write_empty(&gz_path);
                 return;
             }
             Err(e) => {
-                println!("cargo::warning=git not available ({e}) — embedding empty sparse data");
+                println!(
+                    "cargo::warning=git not available ({e}) — embedding empty {} data",
+                    mode.label()
+                );
                 write_empty(&gz_path);
                 return;
             }
         }
     }
 
-    if !sdk_api_content.exists() {
+    if !content_dir.exists() {
         println!(
-            "cargo::warning=sdk-api content not found after submodule init — embedding empty sparse data"
+            "cargo::warning={} content not found after submodule init — embedding empty data",
+            mode.label()
         );
         write_empty(&gz_path);
         return;
     }
 
-    // Check if we can skip regeneration: existing gz is non-empty and
-    // sdk-api hasn't changed since last generation.
-    let current_rev = sdk_api_rev(&sdk_api_dir);
+    // Skip regeneration when the underlying submodule hasn't moved.
+    let current_rev = sub_rev(&submodule_root);
     if is_up_to_date(&gz_path, &stamp_path, current_rev.as_deref()) {
-        eprintln!("bb-sparse: sdk-api unchanged, reusing cached data");
+        eprintln!(
+            "bb-sparse: {} submodule unchanged, reusing cached data",
+            mode.label()
+        );
         return;
     }
 
-    // Run sparse.py to generate the JSON.
-    eprintln!("bb-sparse: running sparse.py to generate API metadata...");
-    let Some(python) = find_python() else {
+    // Locate a runner: `uv` is preferred (matches sparse's own setup);
+    // plain Python is a fallback for hosts where uv isn't installed.
+    let Some(runner) = find_runner() else {
         println!(
-            "cargo::warning=python3 not found on PATH — embedding empty sparse data. Install Python 3 or set BB_SPARSE_JSON"
+            "cargo::warning=neither `uv` nor python3 found on PATH — embedding empty {} data. Install uv (https://docs.astral.sh/uv/) or Python 3, or set {}",
+            mode.label(),
+            mode.override_env()[0]
         );
         write_empty(&gz_path);
         return;
     };
 
-    let generated_json = out_dir.join("sparse_generated.json");
-    let mut cmd = Command::new(&python[0]);
-    cmd.args(&python[1..]);
+    let generated_json = out_dir.join(format!("sparse_{}_generated.json", mode.label()));
+
+    eprintln!(
+        "bb-sparse: running sparse ({} mode) to generate API metadata...",
+        mode.label()
+    );
+
+    // `uv run` needs the project synced first; cheap and idempotent.
+    if matches!(runner, Runner::Uv) {
+        let _ = Command::new("uv")
+            .args(["sync", "--frozen"])
+            .current_dir(sparse_dir)
+            .status();
+    }
+
+    let mut cmd = runner.command(sparse_dir);
     cmd.args([
         sparse_py.to_str().unwrap(),
+        "--mode",
+        mode.sparse_mode_flag(),
         "-o",
         generated_json.to_str().unwrap(),
         "--silent",
-        sdk_api_content.to_str().unwrap(),
+        content_dir.to_str().unwrap(),
     ]);
-    cmd.current_dir(&sparse_dir);
+    cmd.current_dir(sparse_dir);
 
     let output = cmd.output();
 
     match output.as_ref().map(|o| o.status) {
         Ok(s) if s.success() && generated_json.exists() => {
-            eprintln!("bb-sparse: sparse.py completed successfully");
+            eprintln!(
+                "bb-sparse: sparse {} mode completed successfully",
+                mode.label()
+            );
             compress_json(&generated_json, &gz_path);
-            // Write stamp so we can skip next time.
             if let Some(ref rev) = current_rev {
                 let _ = fs::write(&stamp_path, rev);
             }
@@ -136,8 +244,10 @@ fn main() {
                 .as_ref()
                 .map(|o| String::from_utf8_lossy(&o.stderr).to_string())
                 .unwrap_or_default();
-            // Show full traceback: one cargo::warning per line for visibility.
-            println!("cargo::warning=sparse.py failed (exit {s}) — embedding empty data");
+            println!(
+                "cargo::warning=sparse {} mode failed (exit {s}) — embedding empty data",
+                mode.label()
+            );
             for line in stderr.lines().take(20) {
                 if !line.trim().is_empty() {
                     println!("cargo::warning=  {line}");
@@ -146,64 +256,51 @@ fn main() {
             write_empty(&gz_path);
         }
         Err(e) => {
-            println!("cargo::warning=failed to run python ({e}) — embedding empty sparse data");
+            println!(
+                "cargo::warning=failed to run sparse runner ({e}) — embedding empty {} data",
+                mode.label()
+            );
             write_empty(&gz_path);
         }
     }
 }
 
-/* ───────────────────────────────── Helpers ──────────────────────────────── */
+/* ───────────────────────────── Runner detection ─────────────────────────── */
 
-/// Get the current git rev of the sdk-api submodule.
-fn sdk_api_rev(sdk_api_dir: &Path) -> Option<String> {
-    Command::new("git")
-        .args(["rev-parse", "HEAD"])
-        .current_dir(sdk_api_dir)
-        .output()
-        .ok()
-        .filter(|o| o.status.success())
-        .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_string())
+enum Runner {
+    Uv,
+    Python(Vec<String>),
 }
 
-/// Check if the existing compressed data is still valid:
-/// - gz exists and is non-empty
-/// - stamp file contains the same rev as current sdk-api HEAD
-fn is_up_to_date(gz_path: &Path, stamp_path: &Path, current_rev: Option<&str>) -> bool {
-    let gz_ok = gz_path.metadata().is_ok_and(|m| m.len() > 0);
-
-    if !gz_ok {
-        return false;
+impl Runner {
+    fn command(&self, sparse_dir: &Path) -> Command {
+        match self {
+            Self::Uv => {
+                let mut cmd = Command::new("uv");
+                cmd.args(["run", "--project", sparse_dir.to_str().unwrap(), "python"]);
+                cmd
+            }
+            Self::Python(parts) => {
+                let mut cmd = Command::new(&parts[0]);
+                cmd.args(&parts[1..]);
+                cmd
+            }
+        }
     }
-
-    let Some(rev) = current_rev else {
-        return false;
-    };
-
-    fs::read_to_string(stamp_path).is_ok_and(|stored| stored.trim() == rev)
 }
 
-fn compress_json(json_path: &Path, gz_path: &Path) {
-    let raw = fs::read(json_path).expect("failed to read sparse JSON");
-    let mut encoder = GzEncoder::new(Vec::new(), Compression::best());
-    encoder.write_all(&raw).expect("failed to compress");
-    let compressed = encoder.finish().expect("failed to finish compression");
-
-    eprintln!(
-        "bb-sparse: compressed {} -> {} bytes ({:.0}% reduction)",
-        raw.len(),
-        compressed.len(),
-        (1.0 - compressed.len() as f64 / raw.len() as f64) * 100.0,
-    );
-
-    fs::write(gz_path, &compressed).expect("failed to write compressed data");
-}
-
-fn write_empty(gz_path: &Path) {
-    fs::write(gz_path, b"").expect("failed to write empty placeholder");
+fn find_runner() -> Option<Runner> {
+    if Command::new("uv")
+        .arg("--version")
+        .output()
+        .is_ok_and(|o| o.status.success())
+    {
+        return Some(Runner::Uv);
+    }
+    find_python().map(Runner::Python)
 }
 
 fn find_python() -> Option<Vec<String>> {
-    // On Windows, `py -3` uses the Python launcher to find the latest 3.x.
     if cfg!(windows)
         && Command::new("py")
             .args(["-3", "--version"])
@@ -222,6 +319,50 @@ fn find_python() -> Option<Vec<String>> {
         }
     }
     None
+}
+
+/* ───────────────────────────────── Helpers ──────────────────────────────── */
+
+fn sub_rev(submodule_dir: &Path) -> Option<String> {
+    Command::new("git")
+        .args(["rev-parse", "HEAD"])
+        .current_dir(submodule_dir)
+        .output()
+        .ok()
+        .filter(|o| o.status.success())
+        .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_string())
+}
+
+fn is_up_to_date(gz_path: &Path, stamp_path: &Path, current_rev: Option<&str>) -> bool {
+    let gz_ok = gz_path.metadata().is_ok_and(|m| m.len() > 0);
+    if !gz_ok {
+        return false;
+    }
+    let Some(rev) = current_rev else {
+        return false;
+    };
+    fs::read_to_string(stamp_path).is_ok_and(|stored| stored.trim() == rev)
+}
+
+fn compress_json(json_path: &Path, gz_path: &Path) {
+    let raw = fs::read(json_path).expect("failed to read sparse JSON");
+    let mut encoder = GzEncoder::new(Vec::new(), Compression::best());
+    encoder.write_all(&raw).expect("failed to compress");
+    let compressed = encoder.finish().expect("failed to finish compression");
+
+    eprintln!(
+        "bb-sparse: {} -> {} ({} bytes, {:.0}% reduction)",
+        json_path.display(),
+        gz_path.display(),
+        compressed.len(),
+        (1.0 - compressed.len() as f64 / raw.len() as f64) * 100.0,
+    );
+
+    fs::write(gz_path, &compressed).expect("failed to write compressed data");
+}
+
+fn write_empty(gz_path: &Path) {
+    fs::write(gz_path, b"").expect("failed to write empty placeholder");
 }
 
 fn find_workspace_root() -> Option<PathBuf> {

--- a/crates/bb-sparse/src/irql.rs
+++ b/crates/bb-sparse/src/irql.rs
@@ -1,0 +1,249 @@
+//! IRQL constraint type + parsing + numeric comparison.
+//!
+//! The upstream sparse parser pre-normalizes free-form frontmatter strings
+//! like `"<= DISPATCH_LEVEL"` or `"PASSIVE_LEVEL"` into the structured
+//! [`IrqlConstraint`] shape. This module owns that struct, plus a
+//! `parse_constraint` for filter-input strings (used by `bb-funcs --irql`)
+//! and a [`IrqlConstraint::matches`] helper that resolves levels to numeric
+//! values via a caller-supplied constant lookup and applies the constraint
+//! operator.
+
+use std::collections::HashMap;
+
+use serde::{Deserialize, Serialize};
+
+/// Recognized IRQL level identifiers.
+///
+/// `ANY` is a wildcard used by the upstream parser. `DEVICE_LEVEL` and
+/// `DIRQL` are documentation placeholders — they don't have a single
+/// concrete numeric value and won't resolve via [`IrqlConstraint::resolve_level`].
+pub const KNOWN_LEVELS: &[&str] = &[
+    "PASSIVE_LEVEL",
+    "APC_LEVEL",
+    "DISPATCH_LEVEL",
+    "DPC_LEVEL",
+    "DEVICE_LEVEL",
+    "DIRQL",
+    "HIGH_LEVEL",
+    "IPI_LEVEL",
+    "ANY",
+];
+
+/// Recognized comparison operators on IRQL constraints.
+pub const KNOWN_OPS: &[&str] = &["<", "<=", "=", "==", ">=", ">"];
+
+/// Normalized IRQL constraint.
+///
+/// `level` is one of [`KNOWN_LEVELS`]. `op` is one of [`KNOWN_OPS`] or
+/// `None` when the documentation didn't provide an operator (exact match).
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+pub struct IrqlConstraint {
+    pub level: String,
+    #[serde(default)]
+    pub op: Option<String>,
+}
+
+impl IrqlConstraint {
+    /// Resolve `self.level` to its numeric `#define` value via the given
+    /// constant lookup (typically built from a macro-preprocessed kernel-
+    /// mode translation unit).
+    ///
+    /// Returns `None` for `ANY`, `DEVICE_LEVEL`, and `DIRQL` (which don't
+    /// have a single concrete value), or when the constant isn't in the
+    /// lookup table.
+    #[must_use]
+    pub fn resolve_level(&self, lookup: &HashMap<String, u64>) -> Option<u64> {
+        match self.level.as_str() {
+            "ANY" | "DEVICE_LEVEL" | "DIRQL" => None,
+            other => lookup.get(other).copied(),
+        }
+    }
+
+    /// Does this constraint match a filter applied at `filter.level` with
+    /// `filter.op`? Symbolic-match cases short-circuit; otherwise both
+    /// sides are resolved to numeric values via `lookup` and compared
+    /// using `filter.op` (or `=` when `op` is `None`).
+    ///
+    /// Returns `None` when a side can't be resolved numerically and the
+    /// comparison is therefore undefined (the caller decides whether to
+    /// keep or drop the entry).
+    #[must_use]
+    pub fn matches(
+        &self,
+        filter: &IrqlConstraint,
+        lookup: &HashMap<String, u64>,
+    ) -> Option<bool> {
+        // `ANY` filter matches everything.
+        if filter.level == "ANY" {
+            return Some(true);
+        }
+        // Exact symbolic equality covers same-level same-op cases (incl.
+        // both ops being None).
+        if self.level == filter.level && self.op == filter.op {
+            return Some(true);
+        }
+
+        let a = self.resolve_level(lookup)?;
+        let b = filter.resolve_level(lookup)?;
+        let op = filter.op.as_deref().unwrap_or("=");
+        Some(match op {
+            "=" | "==" => a == b,
+            "<" => a < b,
+            "<=" => a <= b,
+            ">" => a > b,
+            ">=" => a >= b,
+            _ => false,
+        })
+    }
+}
+
+/* ─────────────────────────────── Parsing ────────────────────────────────── */
+
+/// Parser errors for [`parse_constraint`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ParseError {
+    Empty,
+    UnknownLevel(String),
+    BadSyntax(String),
+}
+
+impl std::fmt::Display for ParseError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Empty => write!(f, "empty IRQL constraint"),
+            Self::UnknownLevel(l) => write!(
+                f,
+                "unknown IRQL level '{l}' (expected one of: {})",
+                KNOWN_LEVELS.join(", ")
+            ),
+            Self::BadSyntax(s) => write!(f, "bad IRQL syntax: {s:?}"),
+        }
+    }
+}
+
+impl std::error::Error for ParseError {}
+
+/// Parse a filter-input string like `"<= DISPATCH_LEVEL"`, `"PASSIVE_LEVEL"`,
+/// or `"<=DISPATCH_LEVEL"` into an [`IrqlConstraint`].
+///
+/// Whitespace is permissive. The level token is matched case-sensitively
+/// against [`KNOWN_LEVELS`] (since real frontmatter uses uppercase). No-op
+/// strings collapse to `op: None`.
+pub fn parse_constraint(s: &str) -> Result<IrqlConstraint, ParseError> {
+    let s = s.trim();
+    if s.is_empty() {
+        return Err(ParseError::Empty);
+    }
+
+    // Match the longest operator prefix first so "<=" beats "<".
+    let mut op: Option<&str> = None;
+    let mut rest = s;
+    for candidate in ["<=", ">=", "==", "=", "<", ">"] {
+        if let Some(after) = rest.strip_prefix(candidate) {
+            op = Some(candidate);
+            rest = after;
+            break;
+        }
+    }
+
+    let level = rest.trim();
+    if level.is_empty() {
+        return Err(ParseError::BadSyntax(s.into()));
+    }
+    if !KNOWN_LEVELS.iter().any(|&l| l == level) {
+        return Err(ParseError::UnknownLevel(level.into()));
+    }
+
+    Ok(IrqlConstraint {
+        level: level.to_string(),
+        op: op.map(String::from),
+    })
+}
+
+/* ────────────────────────────────── Tests ───────────────────────────────── */
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn lookup() -> HashMap<String, u64> {
+        // Match the canonical x64 wdm.h values.
+        HashMap::from([
+            ("PASSIVE_LEVEL".into(), 0),
+            ("APC_LEVEL".into(), 1),
+            ("DISPATCH_LEVEL".into(), 2),
+            ("DPC_LEVEL".into(), 2),
+            ("HIGH_LEVEL".into(), 31),
+            ("IPI_LEVEL".into(), 29),
+        ])
+    }
+
+    #[test]
+    fn parse_bare_level() {
+        let c = parse_constraint("PASSIVE_LEVEL").unwrap();
+        assert_eq!(c.level, "PASSIVE_LEVEL");
+        assert_eq!(c.op, None);
+    }
+
+    #[test]
+    fn parse_with_op() {
+        let c = parse_constraint("<= DISPATCH_LEVEL").unwrap();
+        assert_eq!(c.level, "DISPATCH_LEVEL");
+        assert_eq!(c.op.as_deref(), Some("<="));
+    }
+
+    #[test]
+    fn parse_no_space() {
+        let c = parse_constraint("<=DISPATCH_LEVEL").unwrap();
+        assert_eq!(c.op.as_deref(), Some("<="));
+    }
+
+    #[test]
+    fn parse_rejects_unknown() {
+        assert!(matches!(
+            parse_constraint("MAGIC_LEVEL"),
+            Err(ParseError::UnknownLevel(_))
+        ));
+    }
+
+    #[test]
+    fn parse_rejects_empty() {
+        assert!(matches!(parse_constraint(""), Err(ParseError::Empty)));
+        assert!(matches!(parse_constraint("<= "), Err(ParseError::BadSyntax(_))));
+    }
+
+    #[test]
+    fn any_filter_matches_everything() {
+        let any = IrqlConstraint { level: "ANY".into(), op: None };
+        let c = IrqlConstraint { level: "DISPATCH_LEVEL".into(), op: None };
+        assert_eq!(c.matches(&any, &lookup()), Some(true));
+    }
+
+    #[test]
+    fn numeric_le_filter() {
+        let filter = parse_constraint("<= DISPATCH_LEVEL").unwrap();
+        let passive = IrqlConstraint { level: "PASSIVE_LEVEL".into(), op: None };
+        let dispatch = IrqlConstraint { level: "DISPATCH_LEVEL".into(), op: None };
+        let high = IrqlConstraint { level: "HIGH_LEVEL".into(), op: None };
+        assert_eq!(passive.matches(&filter, &lookup()), Some(true));
+        assert_eq!(dispatch.matches(&filter, &lookup()), Some(true));
+        assert_eq!(high.matches(&filter, &lookup()), Some(false));
+    }
+
+    #[test]
+    fn exact_filter_matches_by_value() {
+        // DPC_LEVEL and DISPATCH_LEVEL share the numeric value 2.
+        let filter = IrqlConstraint { level: "DPC_LEVEL".into(), op: None };
+        let dispatch = IrqlConstraint { level: "DISPATCH_LEVEL".into(), op: None };
+        assert_eq!(dispatch.matches(&filter, &lookup()), Some(true));
+    }
+
+    #[test]
+    fn unresolvable_levels_return_none() {
+        let filter = parse_constraint("<= DISPATCH_LEVEL").unwrap();
+        let dirql = IrqlConstraint { level: "DIRQL".into(), op: None };
+        let device = IrqlConstraint { level: "DEVICE_LEVEL".into(), op: None };
+        assert_eq!(dirql.matches(&filter, &lookup()), None);
+        assert_eq!(device.matches(&filter, &lookup()), None);
+    }
+}

--- a/crates/bb-sparse/src/lib.rs
+++ b/crates/bb-sparse/src/lib.rs
@@ -7,17 +7,12 @@
 //! driver-specific fields like IRQL constraints and KMDF/UMDF version tags.
 //!
 //! Two JSON blobs are gzip-compressed at build time and decompressed lazily
-//! on first access. SDK and driver entries live in the same lookup space —
-//! [`lookup`] checks SDK first then driver (their function-name spaces are
-//! largely disjoint). Use [`lookup_sdk`] / [`lookup_driver`] for an explicit
-//! per-source query.
-//!
-//! Driver-only metadata (IRQL, KMDF/UMDF version, `target-type`, etc.) is
-//! exposed via [`FuncMetadata::driver`], which returns `Some(&DriverMetadata)`
-//! only for entries that came from the driver dataset. SDK entries always
-//! return `None` here, even if the source JSON were to contain stray fields.
-//!
-//! See `bb-sparse/sparse` for the upstream parser and JSON schema.
+//! on first access. The two datasets are exposed as two distinct types —
+//! [`SdkMetadata`] and [`DriverMetadata`] — that share a common surface
+//! through the [`Metadata`] trait. [`lookup`] returns an [`Entry`] enum that
+//! tags which source the result came from; [`lookup_sdk`] and
+//! [`lookup_driver`] hand back concrete types when you already know the
+//! source.
 
 use std::collections::HashMap;
 use std::io::Read;
@@ -26,10 +21,14 @@ use std::sync::OnceLock;
 use flate2::read::GzDecoder;
 use serde::Deserialize;
 
-/* ────────────────────────────────── Types ───────────────────────────────── */
+pub mod irql;
 
-/// Which sparse dataset a [`FuncMetadata`] entry came from.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub use irql::IrqlConstraint;
+
+/* ────────────────────────────────── Source ──────────────────────────────── */
+
+/// Which sparse dataset an entry came from.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum Source {
     /// MicrosoftDocs/sdk-api — user-mode Win32 APIs.
     Sdk,
@@ -37,53 +36,59 @@ pub enum Source {
     Driver,
 }
 
-/// Metadata for a single Windows API function, sourced from MSDN documentation.
+/* ─────────────────────────── Shared metadata ────────────────────────────── */
+
+/// Fields shared by both sdk-api and windows-driver-docs-ddi frontmatter.
 ///
-/// Fields use `serde_json::Value` where the sparse JSON schema is inconsistent
-/// (some fields are strings in one entry, arrays or null in another).
+/// Kept private — public callers reach these fields through the [`Metadata`]
+/// trait (accessor methods) or through the typed wrappers.
 #[derive(Debug, Clone, Deserialize)]
-pub struct FuncMetadata {
+struct Shared {
     /// Header file (e.g., `"fileapi.h"`).
     #[serde(default)]
-    pub header: serde_json::Value,
-    /// Link library (e.g., `"Kernel32.lib"` or `["lib1", "lib2"]`).
+    header: serde_json::Value,
+    /// Link library (string or array of strings).
     #[serde(default)]
-    pub lib: serde_json::Value,
-    /// DLL name (e.g., `"Kernel32.dll"` or `["dll1", "dll2"]`).
+    lib: serde_json::Value,
+    /// DLL name (string or array of strings).
     #[serde(default)]
-    pub dll: serde_json::Value,
+    dll: serde_json::Value,
     /// Minimum Windows client version.
     #[serde(default)]
-    pub min_client_version: serde_json::Value,
+    min_client_version: serde_json::Value,
     /// Minimum Windows server version.
     #[serde(default)]
-    pub min_server_version: serde_json::Value,
+    min_server_version: serde_json::Value,
     /// Extended API metadata.
     #[serde(default)]
-    pub metadata: Option<ApiMetadata>,
+    metadata: Option<ApiMetadata>,
     /// Per-parameter metadata, keyed by parameter name.
     #[serde(default)]
-    pub params: HashMap<String, ParamMetadata>,
-
-    /// Internal slot for driver-only fields. Always `None` for SDK entries.
-    /// Public access goes through [`FuncMetadata::driver`], which enforces
-    /// the source check.
-    #[serde(skip)]
-    driver: Option<DriverMetadata>,
-
-    /// Which dataset this entry came from. Populated at load time; never
-    /// present in the source JSON.
-    #[serde(skip)]
-    pub source: Option<Source>,
+    params: HashMap<String, ParamMetadata>,
 }
 
-/// Driver-mode-only metadata from `windows-driver-docs-ddi` frontmatter.
+/* ─────────────────────────── SdkMetadata ────────────────────────────────── */
+
+/// Metadata for a single user-mode Win32 API function, from sdk-api.
+#[derive(Debug, Clone, Deserialize)]
+pub struct SdkMetadata {
+    #[serde(flatten)]
+    shared: Shared,
+}
+
+/* ─────────────────────────── DriverMetadata ─────────────────────────────── */
+
+/// Metadata for a single kernel / WDF DDI, from windows-driver-docs-ddi.
 ///
-/// Only present on entries returned by [`lookup_driver`] (or by [`lookup`]
-/// when the SDK dataset doesn't have a matching name).
-#[derive(Debug, Clone, Default, Deserialize)]
+/// Extends the shared MSDN frontmatter with driver-only fields: IRQL
+/// constraints, KMDF/UMDF version requirements, target-type, tech.root,
+/// and the include-header used by driver code.
+#[derive(Debug, Clone, Deserialize)]
 pub struct DriverMetadata {
-    /// `req.include-header` from the page frontmatter.
+    #[serde(flatten)]
+    shared: Shared,
+
+    /// `req.include-header` from the page frontmatter (e.g., `"wdf.h"`).
     #[serde(default)]
     pub include_header: serde_json::Value,
     /// `req.target-type` (e.g., `"Universal"`, `"Desktop"`).
@@ -108,112 +113,6 @@ pub struct DriverMetadata {
     /// couldn't parse).
     #[serde(default)]
     pub irql_raw: serde_json::Value,
-}
-
-/// API-level metadata from the MSDN documentation frontmatter.
-#[derive(Debug, Clone, Deserialize)]
-pub struct ApiMetadata {
-    /// Unique identifier (e.g., `"NF:fileapi.CreateFileW"`).
-    #[serde(default, rename = "UID")]
-    pub uid: serde_json::Value,
-    /// Documentation title.
-    #[serde(default)]
-    pub title: serde_json::Value,
-    /// Short description from the page intro.
-    #[serde(default)]
-    pub description: serde_json::Value,
-    /// API classification (e.g., `["DllExport"]`). May contain nulls.
-    #[serde(default)]
-    pub api_type: Vec<serde_json::Value>,
-    /// All DLL locations where the function exists. May contain nulls.
-    #[serde(default)]
-    pub api_location: Vec<serde_json::Value>,
-    /// Function name variants (e.g., `["CreateFile", "CreateFileA", "CreateFileW"]`).
-    #[serde(default)]
-    pub api_name: Vec<serde_json::Value>,
-}
-
-/// Normalized IRQL constraint.
-///
-/// `level` is one of: `PASSIVE_LEVEL`, `APC_LEVEL`, `DISPATCH_LEVEL`,
-/// `DPC_LEVEL`, `DEVICE_LEVEL`, `DIRQL`, `HIGH_LEVEL`, `IPI_LEVEL`,
-/// or `ANY`. `op` is one of `<`, `<=`, `=`, `==`, `>=`, `>` or `None`
-/// for an exact-or-implicit match.
-#[derive(Debug, Clone, Deserialize)]
-pub struct IrqlConstraint {
-    pub level: String,
-    #[serde(default)]
-    pub op: Option<String>,
-}
-
-/// Per-parameter metadata from MSDN documentation.
-#[derive(Debug, Clone, Deserialize)]
-pub struct ParamMetadata {
-    /// SAL-style directions (e.g., `["in"]`, `["in", "optional"]`, `["out"]`).
-    #[serde(default)]
-    pub directions: Vec<serde_json::Value>,
-    /// Known constant values for this parameter (e.g., `{"FILE_SHARE_READ": 1}`).
-    #[serde(default)]
-    pub values: HashMap<String, serde_json::Value>,
-}
-
-/* ─────────────────────── Value extraction helpers ──────────────────────── */
-
-/// Extract a display string from a `Value` that might be a string or an array of strings.
-fn value_as_display(v: &serde_json::Value) -> Option<String> {
-    match v {
-        serde_json::Value::String(s) => Some(s.clone()),
-        serde_json::Value::Array(arr) => {
-            let strs: Vec<&str> = arr.iter().filter_map(|v| v.as_str()).collect();
-            if strs.is_empty() {
-                None
-            } else {
-                Some(strs.join(", "))
-            }
-        }
-        _ => None,
-    }
-}
-
-/// Extract a `Vec<String>` from a `Vec<Value>`, skipping nulls.
-fn values_as_strings(vals: &[serde_json::Value]) -> Vec<String> {
-    vals.iter()
-        .filter_map(|v| v.as_str().map(String::from))
-        .collect()
-}
-
-impl FuncMetadata {
-    /// Get the header as a string, if available.
-    #[must_use]
-    pub fn header_str(&self) -> Option<&str> {
-        self.header.as_str()
-    }
-    /// Get the lib as a display string (may be a single value or comma-joined array).
-    #[must_use]
-    pub fn lib_display(&self) -> Option<String> {
-        value_as_display(&self.lib)
-    }
-    /// Get the DLL as a display string (may be a single value or comma-joined array).
-    #[must_use]
-    pub fn dll_display(&self) -> Option<String> {
-        value_as_display(&self.dll)
-    }
-    /// Get the minimum client version, if available.
-    #[must_use]
-    pub fn min_client_str(&self) -> Option<&str> {
-        self.min_client_version.as_str()
-    }
-    /// Get the minimum server version, if available.
-    #[must_use]
-    pub fn min_server_str(&self) -> Option<&str> {
-        self.min_server_version.as_str()
-    }
-    /// Driver-only metadata, only present for entries from the driver dataset.
-    /// Returns `None` for SDK entries.
-    #[must_use]
-    pub fn driver(&self) -> Option<&DriverMetadata> {
-        self.driver.as_ref()
-    }
 }
 
 impl DriverMetadata {
@@ -254,46 +153,198 @@ impl DriverMetadata {
     }
 }
 
+/* ────────────────────────── Shared accessor trait ───────────────────────── */
+
+/// Accessors shared by every metadata flavor.
+///
+/// Implemented by both [`SdkMetadata`] and [`DriverMetadata`] so callers that
+/// only care about fields common to both datasets (header, DLL, lib, min
+/// versions, params) can write `&dyn Metadata` once.
+pub trait Metadata {
+    fn header_str(&self) -> Option<&str>;
+    fn lib_display(&self) -> Option<String>;
+    fn dll_display(&self) -> Option<String>;
+    fn min_client_str(&self) -> Option<&str>;
+    fn min_server_str(&self) -> Option<&str>;
+    fn api_metadata(&self) -> Option<&ApiMetadata>;
+    fn params(&self) -> &HashMap<String, ParamMetadata>;
+}
+
+macro_rules! impl_metadata_via_shared {
+    ($t:ty) => {
+        impl Metadata for $t {
+            fn header_str(&self) -> Option<&str> {
+                self.shared.header.as_str()
+            }
+            fn lib_display(&self) -> Option<String> {
+                value_as_display(&self.shared.lib)
+            }
+            fn dll_display(&self) -> Option<String> {
+                value_as_display(&self.shared.dll)
+            }
+            fn min_client_str(&self) -> Option<&str> {
+                self.shared.min_client_version.as_str()
+            }
+            fn min_server_str(&self) -> Option<&str> {
+                self.shared.min_server_version.as_str()
+            }
+            fn api_metadata(&self) -> Option<&ApiMetadata> {
+                self.shared.metadata.as_ref()
+            }
+            fn params(&self) -> &HashMap<String, ParamMetadata> {
+                &self.shared.params
+            }
+        }
+    };
+}
+
+impl_metadata_via_shared!(SdkMetadata);
+impl_metadata_via_shared!(DriverMetadata);
+
+/* ─────────────────────────────── Entry ──────────────────────────────────── */
+
+/// A metadata entry returned by [`lookup`], tagged with its source.
+///
+/// Use [`Entry::as_metadata`] to access the shared fields without caring
+/// which source they came from. Use [`Entry::driver`] to reach the
+/// driver-only fields when you specifically need them.
+#[derive(Debug, Clone, Copy)]
+pub enum Entry<'a> {
+    Sdk(&'a SdkMetadata),
+    Driver(&'a DriverMetadata),
+}
+
+impl<'a> Entry<'a> {
+    /// Borrow this entry as a shared-trait reference.
+    #[must_use]
+    pub fn as_metadata(&self) -> &'a dyn Metadata {
+        match *self {
+            Self::Sdk(m) => m,
+            Self::Driver(m) => m,
+        }
+    }
+
+    /// Which dataset this entry came from.
+    #[must_use]
+    pub fn source(&self) -> Source {
+        match self {
+            Self::Sdk(_) => Source::Sdk,
+            Self::Driver(_) => Source::Driver,
+        }
+    }
+
+    /// Driver-only metadata, if and only if this is a driver entry.
+    #[must_use]
+    pub fn driver(&self) -> Option<&'a DriverMetadata> {
+        match *self {
+            Self::Driver(m) => Some(m),
+            Self::Sdk(_) => None,
+        }
+    }
+
+    /// SDK-only metadata, if and only if this is an SDK entry.
+    #[must_use]
+    pub fn sdk(&self) -> Option<&'a SdkMetadata> {
+        match *self {
+            Self::Sdk(m) => Some(m),
+            Self::Driver(_) => None,
+        }
+    }
+}
+
+/* ─────────────────────────── ApiMetadata / params ───────────────────────── */
+
+/// API-level metadata from the MSDN documentation frontmatter.
+#[derive(Debug, Clone, Deserialize)]
+pub struct ApiMetadata {
+    /// Unique identifier (e.g., `"NF:fileapi.CreateFileW"`).
+    #[serde(default, rename = "UID")]
+    pub uid: serde_json::Value,
+    /// Documentation title.
+    #[serde(default)]
+    pub title: serde_json::Value,
+    /// Short description from the page intro.
+    #[serde(default)]
+    pub description: serde_json::Value,
+    /// API classification (e.g., `["DllExport"]`). May contain nulls.
+    #[serde(default)]
+    pub api_type: Vec<serde_json::Value>,
+    /// All DLL locations where the function exists. May contain nulls.
+    #[serde(default)]
+    pub api_location: Vec<serde_json::Value>,
+    /// Function name variants (e.g., `["CreateFile", "CreateFileA", "CreateFileW"]`).
+    #[serde(default)]
+    pub api_name: Vec<serde_json::Value>,
+}
+
 impl ApiMetadata {
-    /// Get the API location DLLs as strings.
+    /// API location DLLs as strings.
     #[must_use]
     pub fn locations(&self) -> Vec<String> {
         values_as_strings(&self.api_location)
     }
-    /// Get the function name variants as strings.
+    /// Function name variants as strings.
     #[must_use]
     pub fn names(&self) -> Vec<String> {
         values_as_strings(&self.api_name)
     }
-    /// Get the short description, if present.
+    /// Short description, if present.
     #[must_use]
     pub fn description_str(&self) -> Option<&str> {
         self.description.as_str()
     }
 }
 
+/// Per-parameter metadata from MSDN documentation.
+#[derive(Debug, Clone, Deserialize)]
+pub struct ParamMetadata {
+    /// SAL-style directions (e.g., `["in"]`, `["in", "optional"]`, `["out"]`).
+    #[serde(default)]
+    pub directions: Vec<serde_json::Value>,
+    /// Known constant values for this parameter (e.g., `{"FILE_SHARE_READ": 1}`).
+    #[serde(default)]
+    pub values: HashMap<String, serde_json::Value>,
+}
+
 impl ParamMetadata {
-    /// Get the directions as strings.
+    /// Directions as strings.
     #[must_use]
     pub fn direction_strings(&self) -> Vec<String> {
         values_as_strings(&self.directions)
     }
 }
 
+/* ─────────────────────────── Value helpers ──────────────────────────────── */
+
+fn value_as_display(v: &serde_json::Value) -> Option<String> {
+    match v {
+        serde_json::Value::String(s) => Some(s.clone()),
+        serde_json::Value::Array(arr) => {
+            let strs: Vec<&str> = arr.iter().filter_map(|v| v.as_str()).collect();
+            if strs.is_empty() {
+                None
+            } else {
+                Some(strs.join(", "))
+            }
+        }
+        _ => None,
+    }
+}
+
+fn values_as_strings(vals: &[serde_json::Value]) -> Vec<String> {
+    vals.iter()
+        .filter_map(|v| v.as_str().map(String::from))
+        .collect()
+}
+
 /* ──────────────────────── Compressed data embedding ────────────────────── */
 
-/// Gzip-compressed sparse JSON for the SDK dataset, embedded at compile time.
-/// Empty when no data was available at build time.
 static COMPRESSED_SDK: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/sparse_sdk.json.gz"));
-
-/// Gzip-compressed sparse JSON for the driver dataset, embedded at compile time.
 static COMPRESSED_DRIVER: &[u8] =
     include_bytes!(concat!(env!("OUT_DIR"), "/sparse_driver.json.gz"));
 
-/// SDK-only lookup table.
-static LOOKUP_SDK: OnceLock<HashMap<String, FuncMetadata>> = OnceLock::new();
-/// Driver-only lookup table.
-static LOOKUP_DRIVER: OnceLock<HashMap<String, FuncMetadata>> = OnceLock::new();
+static LOOKUP_SDK: OnceLock<HashMap<String, SdkMetadata>> = OnceLock::new();
+static LOOKUP_DRIVER: OnceLock<HashMap<String, DriverMetadata>> = OnceLock::new();
 
 fn decompress(data: &[u8]) -> Option<String> {
     if data.is_empty() {
@@ -307,40 +358,18 @@ fn decompress(data: &[u8]) -> Option<String> {
     Some(out)
 }
 
-fn load(data: &[u8], source: Source) -> HashMap<String, FuncMetadata> {
-    let Some(json) = decompress(data) else {
-        return HashMap::new();
-    };
-
-    let mut map: HashMap<String, FuncMetadata> =
-        serde_json::from_str(&json).expect("failed to parse sparse JSON");
-
-    // Driver-only metadata is gated behind the source: deserialize the same
-    // JSON a second time into DriverMetadata and attach to each entry. This
-    // keeps the FuncMetadata struct uniform while ensuring driver fields are
-    // *only* exposed for driver-source entries.
-    if matches!(source, Source::Driver) {
-        let raw: HashMap<String, DriverMetadata> =
-            serde_json::from_str(&json).expect("failed to parse driver metadata");
-        for (name, dm) in raw {
-            if let Some(entry) = map.get_mut(&name) {
-                entry.driver = Some(dm);
-            }
-        }
-    }
-
-    for v in map.values_mut() {
-        v.source = Some(source);
-    }
-    map
+fn load<T: serde::de::DeserializeOwned>(data: &[u8]) -> HashMap<String, T> {
+    decompress(data)
+        .map(|json| serde_json::from_str(&json).expect("failed to parse sparse JSON"))
+        .unwrap_or_default()
 }
 
-fn sdk_lookup() -> &'static HashMap<String, FuncMetadata> {
-    LOOKUP_SDK.get_or_init(|| load(COMPRESSED_SDK, Source::Sdk))
+fn sdk_lookup() -> &'static HashMap<String, SdkMetadata> {
+    LOOKUP_SDK.get_or_init(|| load(COMPRESSED_SDK))
 }
 
-fn driver_lookup() -> &'static HashMap<String, FuncMetadata> {
-    LOOKUP_DRIVER.get_or_init(|| load(COMPRESSED_DRIVER, Source::Driver))
+fn driver_lookup() -> &'static HashMap<String, DriverMetadata> {
+    LOOKUP_DRIVER.get_or_init(|| load(COMPRESSED_DRIVER))
 }
 
 /* ─────────────────────────── Public API ─────────────────────────────────── */
@@ -351,40 +380,41 @@ fn driver_lookup() -> &'static HashMap<String, FuncMetadata> {
 /// function-name spaces are largely disjoint (user-mode Win32 vs.
 /// kernel/WDF DDIs) so collisions are rare; when one happens, SDK wins.
 ///
-/// Returns `None` if the function isn't in either dataset, or if no
-/// sparse data was embedded at build time.
+/// For mode-aware callers, prefer [`lookup_sdk`] / [`lookup_driver`] and
+/// pick the right one based on context.
 #[must_use]
-pub fn lookup(name: &str) -> Option<&'static FuncMetadata> {
-    sdk_lookup()
-        .get(name)
-        .or_else(|| driver_lookup().get(name))
+pub fn lookup(name: &str) -> Option<Entry<'static>> {
+    if let Some(m) = sdk_lookup().get(name) {
+        return Some(Entry::Sdk(m));
+    }
+    driver_lookup().get(name).map(Entry::Driver)
 }
 
 /// Look up metadata for a function by name in the SDK dataset only.
 #[must_use]
-pub fn lookup_sdk(name: &str) -> Option<&'static FuncMetadata> {
+pub fn lookup_sdk(name: &str) -> Option<&'static SdkMetadata> {
     sdk_lookup().get(name)
 }
 
 /// Look up metadata for a function by name in the driver dataset only.
 #[must_use]
-pub fn lookup_driver(name: &str) -> Option<&'static FuncMetadata> {
+pub fn lookup_driver(name: &str) -> Option<&'static DriverMetadata> {
     driver_lookup().get(name)
 }
 
-/// Returns `true` if **any** sparse data was embedded at build time.
+/// `true` if **any** sparse data was embedded at build time.
 #[must_use]
 pub fn is_available() -> bool {
     is_available_sdk() || is_available_driver()
 }
 
-/// Returns `true` if the SDK dataset was embedded at build time.
+/// `true` if the SDK dataset was embedded at build time.
 #[must_use]
 pub fn is_available_sdk() -> bool {
     !COMPRESSED_SDK.is_empty()
 }
 
-/// Returns `true` if the driver dataset was embedded at build time.
+/// `true` if the driver dataset was embedded at build time.
 #[must_use]
 pub fn is_available_driver() -> bool {
     !COMPRESSED_DRIVER.is_empty()

--- a/crates/bb-sparse/src/lib.rs
+++ b/crates/bb-sparse/src/lib.rs
@@ -1,11 +1,23 @@
 //! Embedded Windows API metadata from [sparse](https://github.com/cristeigabriela/sparse).
 //!
 //! Provides offline lookup of function-level documentation metadata extracted
-//! from Microsoft's sdk-api repository: library/DLL info, version requirements,
-//! parameter directions, and known constant values.
+//! from Microsoft's `sdk-api` repository (user-mode Win32 APIs) **and**
+//! `windows-driver-docs-ddi` (KMDF/UMDF and kernel DDIs): library/DLL info,
+//! version requirements, parameter directions, known constant values, plus
+//! driver-specific fields like IRQL constraints and KMDF/UMDF version tags.
 //!
-//! The JSON data is gzip-compressed at build time and decompressed lazily on
-//! first access.
+//! Two JSON blobs are gzip-compressed at build time and decompressed lazily
+//! on first access. SDK and driver entries live in the same lookup space —
+//! [`lookup`] checks SDK first then driver (their function-name spaces are
+//! largely disjoint). Use [`lookup_sdk`] / [`lookup_driver`] for an explicit
+//! per-source query.
+//!
+//! Driver-only metadata (IRQL, KMDF/UMDF version, `target-type`, etc.) is
+//! exposed via [`FuncMetadata::driver`], which returns `Some(&DriverMetadata)`
+//! only for entries that came from the driver dataset. SDK entries always
+//! return `None` here, even if the source JSON were to contain stray fields.
+//!
+//! See `bb-sparse/sparse` for the upstream parser and JSON schema.
 
 use std::collections::HashMap;
 use std::io::Read;
@@ -15,6 +27,15 @@ use flate2::read::GzDecoder;
 use serde::Deserialize;
 
 /* ────────────────────────────────── Types ───────────────────────────────── */
+
+/// Which sparse dataset a [`FuncMetadata`] entry came from.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Source {
+    /// MicrosoftDocs/sdk-api — user-mode Win32 APIs.
+    Sdk,
+    /// MicrosoftDocs/windows-driver-docs-ddi — kernel / WDF DDIs.
+    Driver,
+}
 
 /// Metadata for a single Windows API function, sourced from MSDN documentation.
 ///
@@ -43,6 +64,50 @@ pub struct FuncMetadata {
     /// Per-parameter metadata, keyed by parameter name.
     #[serde(default)]
     pub params: HashMap<String, ParamMetadata>,
+
+    /// Internal slot for driver-only fields. Always `None` for SDK entries.
+    /// Public access goes through [`FuncMetadata::driver`], which enforces
+    /// the source check.
+    #[serde(skip)]
+    driver: Option<DriverMetadata>,
+
+    /// Which dataset this entry came from. Populated at load time; never
+    /// present in the source JSON.
+    #[serde(skip)]
+    pub source: Option<Source>,
+}
+
+/// Driver-mode-only metadata from `windows-driver-docs-ddi` frontmatter.
+///
+/// Only present on entries returned by [`lookup_driver`] (or by [`lookup`]
+/// when the SDK dataset doesn't have a matching name).
+#[derive(Debug, Clone, Default, Deserialize)]
+pub struct DriverMetadata {
+    /// `req.include-header` from the page frontmatter.
+    #[serde(default)]
+    pub include_header: serde_json::Value,
+    /// `req.target-type` (e.g., `"Universal"`, `"Desktop"`).
+    #[serde(default)]
+    pub target_type: serde_json::Value,
+    /// `req.construct-type` (e.g., `"function"`, `"macro"`, `"method"`).
+    #[serde(default)]
+    pub construct_type: serde_json::Value,
+    /// `req.kmdf-ver` — minimum KMDF version string.
+    #[serde(default)]
+    pub kmdf_ver: serde_json::Value,
+    /// `req.umdf-ver` — minimum UMDF version string.
+    #[serde(default)]
+    pub umdf_ver: serde_json::Value,
+    /// `tech.root` — top-level driver tech category (e.g., `"storage"`).
+    #[serde(default)]
+    pub tech_root: serde_json::Value,
+    /// Normalized IRQL constraint: `{ "level": "...", "op": "<=" }` or `null`.
+    #[serde(default)]
+    pub irql: Option<IrqlConstraint>,
+    /// Raw IRQL string before normalization (for entries the grammar
+    /// couldn't parse).
+    #[serde(default)]
+    pub irql_raw: serde_json::Value,
 }
 
 /// API-level metadata from the MSDN documentation frontmatter.
@@ -54,6 +119,9 @@ pub struct ApiMetadata {
     /// Documentation title.
     #[serde(default)]
     pub title: serde_json::Value,
+    /// Short description from the page intro.
+    #[serde(default)]
+    pub description: serde_json::Value,
     /// API classification (e.g., `["DllExport"]`). May contain nulls.
     #[serde(default)]
     pub api_type: Vec<serde_json::Value>,
@@ -63,6 +131,19 @@ pub struct ApiMetadata {
     /// Function name variants (e.g., `["CreateFile", "CreateFileA", "CreateFileW"]`).
     #[serde(default)]
     pub api_name: Vec<serde_json::Value>,
+}
+
+/// Normalized IRQL constraint.
+///
+/// `level` is one of: `PASSIVE_LEVEL`, `APC_LEVEL`, `DISPATCH_LEVEL`,
+/// `DPC_LEVEL`, `DEVICE_LEVEL`, `DIRQL`, `HIGH_LEVEL`, `IPI_LEVEL`,
+/// or `ANY`. `op` is one of `<`, `<=`, `=`, `==`, `>=`, `>` or `None`
+/// for an exact-or-implicit match.
+#[derive(Debug, Clone, Deserialize)]
+pub struct IrqlConstraint {
+    pub level: String,
+    #[serde(default)]
+    pub op: Option<String>,
 }
 
 /// Per-parameter metadata from MSDN documentation.
@@ -127,6 +208,50 @@ impl FuncMetadata {
     pub fn min_server_str(&self) -> Option<&str> {
         self.min_server_version.as_str()
     }
+    /// Driver-only metadata, only present for entries from the driver dataset.
+    /// Returns `None` for SDK entries.
+    #[must_use]
+    pub fn driver(&self) -> Option<&DriverMetadata> {
+        self.driver.as_ref()
+    }
+}
+
+impl DriverMetadata {
+    /// `req.include-header`, if available.
+    #[must_use]
+    pub fn include_header_str(&self) -> Option<&str> {
+        self.include_header.as_str()
+    }
+    /// `req.target-type`, if available.
+    #[must_use]
+    pub fn target_type_str(&self) -> Option<&str> {
+        self.target_type.as_str()
+    }
+    /// `req.construct-type`, if available.
+    #[must_use]
+    pub fn construct_type_str(&self) -> Option<&str> {
+        self.construct_type.as_str()
+    }
+    /// Minimum KMDF version, if available.
+    #[must_use]
+    pub fn kmdf_ver_str(&self) -> Option<&str> {
+        self.kmdf_ver.as_str()
+    }
+    /// Minimum UMDF version, if available.
+    #[must_use]
+    pub fn umdf_ver_str(&self) -> Option<&str> {
+        self.umdf_ver.as_str()
+    }
+    /// Tech root (e.g., `"storage"`), if available.
+    #[must_use]
+    pub fn tech_root_str(&self) -> Option<&str> {
+        self.tech_root.as_str()
+    }
+    /// Raw IRQL string before normalization, if any.
+    #[must_use]
+    pub fn irql_raw_str(&self) -> Option<&str> {
+        self.irql_raw.as_str()
+    }
 }
 
 impl ApiMetadata {
@@ -140,6 +265,11 @@ impl ApiMetadata {
     pub fn names(&self) -> Vec<String> {
         values_as_strings(&self.api_name)
     }
+    /// Get the short description, if present.
+    #[must_use]
+    pub fn description_str(&self) -> Option<&str> {
+        self.description.as_str()
+    }
 }
 
 impl ParamMetadata {
@@ -152,46 +282,128 @@ impl ParamMetadata {
 
 /* ──────────────────────── Compressed data embedding ────────────────────── */
 
-/// The gzip-compressed sparse JSON, embedded at compile time.
-/// If no data file was present at build time, this is an empty slice.
-static COMPRESSED_DATA: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/sparse.json.gz"));
+/// Gzip-compressed sparse JSON for the SDK dataset, embedded at compile time.
+/// Empty when no data was available at build time.
+static COMPRESSED_SDK: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/sparse_sdk.json.gz"));
 
-/// Lazily decompressed and deserialized lookup table.
-static LOOKUP: OnceLock<HashMap<String, FuncMetadata>> = OnceLock::new();
+/// Gzip-compressed sparse JSON for the driver dataset, embedded at compile time.
+static COMPRESSED_DRIVER: &[u8] =
+    include_bytes!(concat!(env!("OUT_DIR"), "/sparse_driver.json.gz"));
 
-fn load_lookup() -> HashMap<String, FuncMetadata> {
-    if COMPRESSED_DATA.is_empty() {
+/// SDK-only lookup table.
+static LOOKUP_SDK: OnceLock<HashMap<String, FuncMetadata>> = OnceLock::new();
+/// Driver-only lookup table.
+static LOOKUP_DRIVER: OnceLock<HashMap<String, FuncMetadata>> = OnceLock::new();
+
+fn decompress(data: &[u8]) -> Option<String> {
+    if data.is_empty() {
+        return None;
+    }
+    let mut decoder = GzDecoder::new(data);
+    let mut out = String::new();
+    decoder
+        .read_to_string(&mut out)
+        .expect("failed to decompress sparse data");
+    Some(out)
+}
+
+fn load(data: &[u8], source: Source) -> HashMap<String, FuncMetadata> {
+    let Some(json) = decompress(data) else {
         return HashMap::new();
+    };
+
+    let mut map: HashMap<String, FuncMetadata> =
+        serde_json::from_str(&json).expect("failed to parse sparse JSON");
+
+    // Driver-only metadata is gated behind the source: deserialize the same
+    // JSON a second time into DriverMetadata and attach to each entry. This
+    // keeps the FuncMetadata struct uniform while ensuring driver fields are
+    // *only* exposed for driver-source entries.
+    if matches!(source, Source::Driver) {
+        let raw: HashMap<String, DriverMetadata> =
+            serde_json::from_str(&json).expect("failed to parse driver metadata");
+        for (name, dm) in raw {
+            if let Some(entry) = map.get_mut(&name) {
+                entry.driver = Some(dm);
+            }
+        }
     }
 
-    let mut decoder = GzDecoder::new(COMPRESSED_DATA);
-    let mut json_str = String::new();
-    decoder
-        .read_to_string(&mut json_str)
-        .expect("failed to decompress sparse data");
+    for v in map.values_mut() {
+        v.source = Some(source);
+    }
+    map
+}
 
-    serde_json::from_str(&json_str).expect("failed to parse sparse JSON")
+fn sdk_lookup() -> &'static HashMap<String, FuncMetadata> {
+    LOOKUP_SDK.get_or_init(|| load(COMPRESSED_SDK, Source::Sdk))
+}
+
+fn driver_lookup() -> &'static HashMap<String, FuncMetadata> {
+    LOOKUP_DRIVER.get_or_init(|| load(COMPRESSED_DRIVER, Source::Driver))
 }
 
 /* ─────────────────────────── Public API ─────────────────────────────────── */
 
 /// Look up metadata for a function by name.
 ///
-/// Returns `None` if the function is not in the sparse database, or if
-/// no sparse data was embedded at build time.
+/// Checks the SDK dataset first, then the driver dataset. The two
+/// function-name spaces are largely disjoint (user-mode Win32 vs.
+/// kernel/WDF DDIs) so collisions are rare; when one happens, SDK wins.
+///
+/// Returns `None` if the function isn't in either dataset, or if no
+/// sparse data was embedded at build time.
 #[must_use]
 pub fn lookup(name: &str) -> Option<&'static FuncMetadata> {
-    LOOKUP.get_or_init(load_lookup).get(name)
+    sdk_lookup()
+        .get(name)
+        .or_else(|| driver_lookup().get(name))
 }
 
-/// Returns `true` if sparse data was embedded at build time.
+/// Look up metadata for a function by name in the SDK dataset only.
+#[must_use]
+pub fn lookup_sdk(name: &str) -> Option<&'static FuncMetadata> {
+    sdk_lookup().get(name)
+}
+
+/// Look up metadata for a function by name in the driver dataset only.
+#[must_use]
+pub fn lookup_driver(name: &str) -> Option<&'static FuncMetadata> {
+    driver_lookup().get(name)
+}
+
+/// Returns `true` if **any** sparse data was embedded at build time.
 #[must_use]
 pub fn is_available() -> bool {
-    !COMPRESSED_DATA.is_empty()
+    is_available_sdk() || is_available_driver()
 }
 
-/// Returns the number of functions in the sparse database.
+/// Returns `true` if the SDK dataset was embedded at build time.
+#[must_use]
+pub fn is_available_sdk() -> bool {
+    !COMPRESSED_SDK.is_empty()
+}
+
+/// Returns `true` if the driver dataset was embedded at build time.
+#[must_use]
+pub fn is_available_driver() -> bool {
+    !COMPRESSED_DRIVER.is_empty()
+}
+
+/// Total number of functions across both datasets.
 #[must_use]
 pub fn entry_count() -> usize {
-    LOOKUP.get_or_init(load_lookup).len()
+    entry_count_sdk() + entry_count_driver()
+}
+
+/// Number of functions in the SDK dataset.
+#[must_use]
+pub fn entry_count_sdk() -> usize {
+    sdk_lookup().len()
+}
+
+/// Number of functions in the driver dataset.
+#[must_use]
+pub fn entry_count_driver() -> usize {
+    driver_lookup().len()
 }

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -14,6 +14,7 @@ bb-funcs = { path = "../cli/bb-funcs" }
 bb-types = { path = "../cli/bb-types" }
 bb-clang.workspace = true
 bb-sdk.workspace = true
+bb-sparse.workspace = true
 clang.workspace = true
 anyhow.workspace = true
 serial_test.workspace = true

--- a/tests/src/integration.rs
+++ b/tests/src/integration.rs
@@ -1128,6 +1128,7 @@ mod tests {
             sort: None,
             sort_dir: bb_funcs_lib::SortDir::Asc,
             where_clause: None,
+            irql_filter: None,
             first: None,
         }
     }

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -1,1 +1,2 @@
 mod integration;
+mod sparse;

--- a/tests/src/sparse.rs
+++ b/tests/src/sparse.rs
@@ -1,0 +1,181 @@
+//! Unit-style tests for `bb-sparse`. These don't need a clang translation
+//! unit; integration tests that parse real Windows headers live in
+//! `integration.rs`.
+//!
+//! Many tests can only assert real invariants when the relevant dataset was
+//! embedded at build time. On a clean checkout without submodules (or in
+//! environments without uv/Python), bb-sparse embeds an empty placeholder
+//! and `is_available_*` returns false — those tests degrade to compile-time
+//! + smoke checks rather than failing. CI initializes both submodules, so
+//! the data-bearing assertions run there.
+
+#![cfg(test)]
+
+use bb_sparse::Source;
+
+/* ───────────────────────────── Smoke invariants ─────────────────────────── */
+
+#[test]
+fn counts_match_combined_count() {
+    assert_eq!(
+        bb_sparse::entry_count(),
+        bb_sparse::entry_count_sdk() + bb_sparse::entry_count_driver(),
+    );
+}
+
+#[test]
+fn availability_flags_consistent_with_counts() {
+    assert_eq!(
+        bb_sparse::is_available_sdk(),
+        bb_sparse::entry_count_sdk() > 0,
+    );
+    assert_eq!(
+        bb_sparse::is_available_driver(),
+        bb_sparse::entry_count_driver() > 0,
+    );
+    assert_eq!(
+        bb_sparse::is_available(),
+        bb_sparse::is_available_sdk() || bb_sparse::is_available_driver(),
+    );
+}
+
+#[test]
+fn missing_function_returns_none() {
+    let name = "__bb_sparse_definitely_not_a_real_function__";
+    assert!(bb_sparse::lookup(name).is_none());
+    assert!(bb_sparse::lookup_sdk(name).is_none());
+    assert!(bb_sparse::lookup_driver(name).is_none());
+}
+
+/* ─────────────────────────── SDK content assertions ─────────────────────── */
+
+#[test]
+fn sdk_createfilew_has_expected_metadata() {
+    if !bb_sparse::is_available_sdk() {
+        eprintln!("skipping — SDK dataset not embedded");
+        return;
+    }
+    let m = bb_sparse::lookup_sdk("CreateFileW").expect("CreateFileW missing from SDK dataset");
+
+    assert_eq!(m.source, Some(Source::Sdk));
+    assert!(
+        m.driver().is_none(),
+        "SDK entry should not expose driver metadata"
+    );
+
+    // Shared fields — anchored on the well-known MSDN values.
+    assert_eq!(m.header_str(), Some("fileapi.h"));
+    assert_eq!(m.lib_display().as_deref(), Some("Kernel32.lib"));
+    assert!(
+        m.dll_display()
+            .as_deref()
+            .is_some_and(|d| d.contains("Kernel32")),
+        "expected Kernel32-family DLL on CreateFileW, got {:?}",
+        m.dll_display(),
+    );
+
+    // Parameters mirror the documented signature.
+    for p in [
+        "lpFileName",
+        "dwDesiredAccess",
+        "dwShareMode",
+        "lpSecurityAttributes",
+        "dwCreationDisposition",
+        "dwFlagsAndAttributes",
+        "hTemplateFile",
+    ] {
+        assert!(
+            m.params.contains_key(p),
+            "CreateFileW missing parameter {p}"
+        );
+    }
+
+    // dwShareMode carries the well-known FILE_SHARE_* constant set.
+    let share = m
+        .params
+        .get("dwShareMode")
+        .expect("dwShareMode parameter");
+    for v in ["FILE_SHARE_READ", "FILE_SHARE_WRITE", "FILE_SHARE_DELETE"] {
+        assert!(
+            share.values.contains_key(v),
+            "CreateFileW dwShareMode missing known constant {v}"
+        );
+    }
+
+    // ApiMetadata: names contain the A/W/base variants; description present.
+    let api = m.metadata.as_ref().expect("CreateFileW has metadata");
+    let names = api.names();
+    for v in ["CreateFile", "CreateFileA", "CreateFileW"] {
+        assert!(
+            names.iter().any(|n| n == v),
+            "CreateFileW api_name missing {v}, got {names:?}"
+        );
+    }
+    assert!(
+        api.description_str()
+            .is_some_and(|d| d.contains("file") || d.contains("File")),
+        "expected non-trivial description on CreateFileW"
+    );
+}
+
+/* ────────────────────────── Driver content assertions ──────────────────── */
+
+#[test]
+fn driver_entry_exposes_driver_metadata() {
+    if !bb_sparse::is_available_driver() {
+        eprintln!("skipping — driver dataset not embedded");
+        return;
+    }
+    // GET_VENDOR_ID_FROM_PARAMSET is a small, stable macro entry — useful
+    // for asserting the basic driver fields (tech_root, construct_type).
+    let m = bb_sparse::lookup_driver("GET_VENDOR_ID_FROM_PARAMSET")
+        .expect("GET_VENDOR_ID_FROM_PARAMSET missing from driver dataset");
+
+    assert_eq!(m.source, Some(Source::Driver));
+    assert_eq!(m.header_str(), Some("a2dpsidebandaudio.h"));
+
+    let drv = m
+        .driver()
+        .expect("driver-source entry should expose driver()");
+    assert_eq!(drv.tech_root_str(), Some("audio"));
+    assert_eq!(drv.construct_type_str(), Some("function"));
+}
+
+#[test]
+fn driver_entry_has_irql_and_kmdf_when_documented() {
+    if !bb_sparse::is_available_driver() {
+        eprintln!("skipping — driver dataset not embedded");
+        return;
+    }
+    // MBB_DEVICE_CONFIG_INIT is documented with PASSIVE_LEVEL IRQL, KMDF
+    // 1.27, and Universal target-type — a good anchor for the full driver
+    // field set.
+    let m = bb_sparse::lookup_driver("MBB_DEVICE_CONFIG_INIT")
+        .expect("MBB_DEVICE_CONFIG_INIT missing from driver dataset");
+    let drv = m.driver().expect("driver metadata expected");
+
+    let irql = drv.irql.as_ref().expect("expected an IRQL constraint");
+    assert_eq!(irql.level, "PASSIVE_LEVEL");
+
+    assert_eq!(drv.kmdf_ver_str(), Some("1.27"));
+    assert_eq!(drv.target_type_str(), Some("Universal"));
+    assert_eq!(drv.tech_root_str(), Some("netvista"));
+
+    let api = m.metadata.as_ref().expect("has API metadata");
+    assert!(
+        api.description_str()
+            .is_some_and(|d| d.contains("MBB_DEVICE_CONFIG")),
+        "expected description to mention the struct name"
+    );
+}
+
+#[test]
+fn combined_lookup_prefers_sdk() {
+    if !bb_sparse::is_available_sdk() {
+        return;
+    }
+    let Some(m) = bb_sparse::lookup("CreateFileW") else {
+        return;
+    };
+    assert_eq!(m.source, Some(Source::Sdk));
+}

--- a/tests/src/sparse.rs
+++ b/tests/src/sparse.rs
@@ -11,7 +11,7 @@
 
 #![cfg(test)]
 
-use bb_sparse::Source;
+use bb_sparse::{Entry, Metadata};
 
 /* ───────────────────────────── Smoke invariants ─────────────────────────── */
 
@@ -57,12 +57,6 @@ fn sdk_createfilew_has_expected_metadata() {
     }
     let m = bb_sparse::lookup_sdk("CreateFileW").expect("CreateFileW missing from SDK dataset");
 
-    assert_eq!(m.source, Some(Source::Sdk));
-    assert!(
-        m.driver().is_none(),
-        "SDK entry should not expose driver metadata"
-    );
-
     // Shared fields — anchored on the well-known MSDN values.
     assert_eq!(m.header_str(), Some("fileapi.h"));
     assert_eq!(m.lib_display().as_deref(), Some("Kernel32.lib"));
@@ -85,14 +79,14 @@ fn sdk_createfilew_has_expected_metadata() {
         "hTemplateFile",
     ] {
         assert!(
-            m.params.contains_key(p),
+            m.params().contains_key(p),
             "CreateFileW missing parameter {p}"
         );
     }
 
     // dwShareMode carries the well-known FILE_SHARE_* constant set.
     let share = m
-        .params
+        .params()
         .get("dwShareMode")
         .expect("dwShareMode parameter");
     for v in ["FILE_SHARE_READ", "FILE_SHARE_WRITE", "FILE_SHARE_DELETE"] {
@@ -103,7 +97,7 @@ fn sdk_createfilew_has_expected_metadata() {
     }
 
     // ApiMetadata: names contain the A/W/base variants; description present.
-    let api = m.metadata.as_ref().expect("CreateFileW has metadata");
+    let api = m.api_metadata().expect("CreateFileW has metadata");
     let names = api.names();
     for v in ["CreateFile", "CreateFileA", "CreateFileW"] {
         assert!(
@@ -131,14 +125,9 @@ fn driver_entry_exposes_driver_metadata() {
     let m = bb_sparse::lookup_driver("GET_VENDOR_ID_FROM_PARAMSET")
         .expect("GET_VENDOR_ID_FROM_PARAMSET missing from driver dataset");
 
-    assert_eq!(m.source, Some(Source::Driver));
     assert_eq!(m.header_str(), Some("a2dpsidebandaudio.h"));
-
-    let drv = m
-        .driver()
-        .expect("driver-source entry should expose driver()");
-    assert_eq!(drv.tech_root_str(), Some("audio"));
-    assert_eq!(drv.construct_type_str(), Some("function"));
+    assert_eq!(m.tech_root_str(), Some("audio"));
+    assert_eq!(m.construct_type_str(), Some("function"));
 }
 
 #[test]
@@ -152,16 +141,15 @@ fn driver_entry_has_irql_and_kmdf_when_documented() {
     // field set.
     let m = bb_sparse::lookup_driver("MBB_DEVICE_CONFIG_INIT")
         .expect("MBB_DEVICE_CONFIG_INIT missing from driver dataset");
-    let drv = m.driver().expect("driver metadata expected");
 
-    let irql = drv.irql.as_ref().expect("expected an IRQL constraint");
+    let irql = m.irql.as_ref().expect("expected an IRQL constraint");
     assert_eq!(irql.level, "PASSIVE_LEVEL");
 
-    assert_eq!(drv.kmdf_ver_str(), Some("1.27"));
-    assert_eq!(drv.target_type_str(), Some("Universal"));
-    assert_eq!(drv.tech_root_str(), Some("netvista"));
+    assert_eq!(m.kmdf_ver_str(), Some("1.27"));
+    assert_eq!(m.target_type_str(), Some("Universal"));
+    assert_eq!(m.tech_root_str(), Some("netvista"));
 
-    let api = m.metadata.as_ref().expect("has API metadata");
+    let api = m.api_metadata().expect("has API metadata");
     assert!(
         api.description_str()
             .is_some_and(|d| d.contains("MBB_DEVICE_CONFIG")),
@@ -169,13 +157,56 @@ fn driver_entry_has_irql_and_kmdf_when_documented() {
     );
 }
 
+/* ────────────────────────── Entry / lookup precedence ───────────────────── */
+
 #[test]
 fn combined_lookup_prefers_sdk() {
     if !bb_sparse::is_available_sdk() {
         return;
     }
-    let Some(m) = bb_sparse::lookup("CreateFileW") else {
+    let Some(entry) = bb_sparse::lookup("CreateFileW") else {
         return;
     };
-    assert_eq!(m.source, Some(Source::Sdk));
+    assert!(matches!(entry, Entry::Sdk(_)));
+    // SDK entry has no `driver()`.
+    assert!(entry.driver().is_none());
+}
+
+#[test]
+fn entry_driver_returns_some_for_driver_source() {
+    if !bb_sparse::is_available_driver() {
+        return;
+    }
+    // Pick a name that lives in the driver dataset only.
+    let Some(entry) = bb_sparse::lookup("MBB_DEVICE_CONFIG_INIT") else {
+        return;
+    };
+    assert!(matches!(entry, Entry::Driver(_)));
+    let drv = entry.driver().expect("driver entry exposes .driver()");
+    assert!(drv.irql.is_some());
+}
+
+/* ─────────────────────────── IrqlConstraint smoke ───────────────────────── */
+
+#[test]
+fn irql_constraint_parses_and_matches() {
+    use std::collections::HashMap;
+
+    let filter = bb_sparse::irql::parse_constraint("<= DISPATCH_LEVEL").unwrap();
+    let lookup = HashMap::from([
+        ("PASSIVE_LEVEL".to_string(), 0u64),
+        ("DISPATCH_LEVEL".to_string(), 2u64),
+        ("HIGH_LEVEL".to_string(), 31u64),
+    ]);
+
+    let passive = bb_sparse::IrqlConstraint {
+        level: "PASSIVE_LEVEL".into(),
+        op: None,
+    };
+    let high = bb_sparse::IrqlConstraint {
+        level: "HIGH_LEVEL".into(),
+        op: None,
+    };
+    assert_eq!(passive.matches(&filter, &lookup), Some(true));
+    assert_eq!(high.matches(&filter, &lookup), Some(false));
 }

--- a/update-submodules.ps1
+++ b/update-submodules.ps1
@@ -28,11 +28,35 @@ function Update-Sparse {
     git submodule update --init crates/bb-sparse/sparse
     if ($LASTEXITCODE -ne 0) { throw "Failed to update sparse submodule" }
 
-    Write-Host "Updating sparse/sdk-api nested submodule..." -ForegroundColor Cyan
+    # Initialize sparse's nested data submodules: sdk-api (user-mode Win32)
+    # and windows-driver-docs-ddi (KMDF/UMDF + kernel DDIs). Both are needed
+    # so bb-sparse can embed metadata for both modes.
     Push-Location crates/bb-sparse/sparse
-    git submodule update --init sdk-api
-    if ($LASTEXITCODE -ne 0) { Pop-Location; throw "Failed to update sdk-api submodule" }
-    Pop-Location
+    try {
+        Write-Host "Updating sparse/sdk-api nested submodule..." -ForegroundColor Cyan
+        git submodule update --init sdk-api
+        if ($LASTEXITCODE -ne 0) { throw "Failed to update sdk-api submodule" }
+
+        Write-Host "Updating sparse/windows-driver-docs-ddi nested submodule..." -ForegroundColor Cyan
+        git submodule update --init windows-driver-docs-ddi
+        if ($LASTEXITCODE -ne 0) { throw "Failed to update windows-driver-docs-ddi submodule" }
+
+        # `uv sync` pulls sparse's Python dependencies into a local virtualenv
+        # so `uv run python sparse.py ...` works during the bb-sparse build.
+        # If uv isn't installed, fall back gracefully — bb-sparse's build.rs
+        # will retry with plain `python` and surface a warning.
+        $uv = Get-Command uv -ErrorAction SilentlyContinue
+        if ($null -ne $uv) {
+            Write-Host "Syncing sparse Python dependencies via uv..." -ForegroundColor Cyan
+            uv sync --frozen
+            if ($LASTEXITCODE -ne 0) { throw "uv sync failed" }
+        } else {
+            Write-Host "uv not found on PATH — skipping `uv sync`." -ForegroundColor Yellow
+            Write-Host "  Install uv (https://docs.astral.sh/uv/) for the fastest build path." -ForegroundColor Yellow
+        }
+    } finally {
+        Pop-Location
+    }
 
     Write-Host "sparse submodule ready." -ForegroundColor Green
 }

--- a/update-submodules.ps1
+++ b/update-submodules.ps1
@@ -51,8 +51,8 @@ function Update-Sparse {
             uv sync --frozen
             if ($LASTEXITCODE -ne 0) { throw "uv sync failed" }
         } else {
-            Write-Host "uv not found on PATH — skipping `uv sync`." -ForegroundColor Yellow
-            Write-Host "  Install uv (https://docs.astral.sh/uv/) for the fastest build path." -ForegroundColor Yellow
+            Write-Host 'uv not found on PATH - skipping uv sync.' -ForegroundColor Yellow
+            Write-Host '  Install uv (https://docs.astral.sh/uv/) for the fastest build path.' -ForegroundColor Yellow
         }
     } finally {
         Pop-Location


### PR DESCRIPTION
## Summary

Embeds two MSDN datasets in `bb-sparse`: `sdk-api` (user-mode Win32) and `windows-driver-docs-ddi` (KMDF/UMDF + kernel DDIs). Surfaces the new driver-only fields in `bb-funcs` and adds an `--irql` filter for kernel-mode work.

### `bb-sparse`

- New gated public API: `lookup` / `lookup_sdk` / `lookup_driver`, `is_available_*`, `entry_count_*`.
- `lookup` returns an `Entry::Sdk` / `Entry::Driver` enum — SDK entries can never expose driver-only fields.
- `SdkMetadata` and `DriverMetadata` share a `Metadata` trait; driver-only fields (`irql`, `kmdf_ver`, `umdf_ver`, `target_type`, `tech_root`, `include`) live directly on `DriverMetadata`.
- New `irql` module: `IrqlConstraint` + `parse_constraint` + a `matches` helper that resolves `PASSIVE_LEVEL` / `APC_LEVEL` / `DISPATCH_LEVEL` / `HIGH_LEVEL` / etc. through a caller-supplied `HashMap<String, u64>`. Grammar: `[<|<=|=|==|>=|>] LEVEL`.

### `bb-funcs`

- Detail view, `--json`, and `--sqlite` now expose driver metadata (`driver` block / column) when the entry comes from the driver dataset.
- New `--irql CONSTRAINT` filter. `bb-funcs` builds the numeric IRQL lookup from the macro-preprocessed kernel TU it already parses, so symbolic comparisons (`<= DISPATCH_LEVEL`) resolve correctly.
- Mode-aware combined lookup: `--mode kernel` tries `lookup_driver` first; `--mode user` tries `lookup_sdk` first.
- `--first` is now applied as the final pipeline step (after `--irql` and any other post-collection filter) so combinations like `--first 1 --irql APC_LEVEL` return what you'd expect.

### Build / CI

- Switched build to **uv** (`uv run python sparse.py`) with a plain-`python` / `py -3` fallback. New env overrides: `BB_SPARSE_SDK_JSON`, `BB_SPARSE_DRIVER_JSON` (legacy `BB_SPARSE_JSON` still works as an alias for SDK).
- `update-submodules.ps1` now initializes both nested sparse submodules and runs `uv sync`.
- `test.yml` and `release.yml` swap `pip install -r requirements.txt` for `astral-sh/setup-uv@v5`.
- New `.github/workflows/version-check.yml`: PRs targeting `master` must bump `workspace.package.version`.

### `bb-clang`

- `SourceRange::tokenize()` is now wrapped by `pub(crate) safe_tokenize` to guard against inverted / cross-file source ranges. clang-rs 2.0.0 leaves the token-array pointer uninitialized when `clang_tokenize` writes `count == 0`; Rust 1.78+ promotes the resulting `slice::from_raw_parts` precondition into a non-unwinding abort. Kernel-mode parses trip it on synthesized decls in `wdm.h` / `ntddk.h`.

### Tests

- `tests/src/sparse.rs` — content-anchored assertions for `CreateFileW` (SDK), `GET_VENDOR_ID_FROM_PARAMSET` and `MBB_DEVICE_CONFIG_INIT` (driver), and a guard that SDK entries never expose `driver()`.

### Version

`0.2.1` → `0.3.0`.

## Test plan

- [x] `cargo build --workspace` (Windows + MSVC)
- [x] `cargo test --workspace -- --test-threads=1` — 71/71 pass
- [x] `bb-funcs --mode kernel --irql APC_LEVEL --first 1` returns a single result with `irql: <= APC_LEVEL`
- [x] `bb-funcs --name CreateFileW` renders SDK metadata; `bb-funcs --mode kernel --name WdfCollectionAdd` renders the driver block
- [ ] CI: `test.yml` runs cleanly via uv
- [ ] CI: `version-check.yml` confirms the 0.2.1 → 0.3.0 bump