### PR TITLE
feat(bb-sdk): full SDK / PHNT coverage expansion + clang-rs fork

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -383,8 +383,7 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 [[package]]
 name = "clang"
 version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84c044c781163c001b913cd018fc95a628c50d0d2dfea8bca77dad71edb16e37"
+source = "git+https://github.com/KyleMayes/clang-rs?rev=35b355e0bdfc52d37c7e93e814f54388d202dff1#35b355e0bdfc52d37c7e93e814f54388d202dff1"
 dependencies = [
  "clang-sys",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ bb-cli = { path = "crates/bb-cli" }
 bb-sql = { path = "crates/bb-sql" }
 bb-tui = { path = "crates/bb-tui" }
 
-clang = { version = "2.0.0", features = ["clang_10_0"] }
+clang = { git = "https://github.com/KyleMayes/clang-rs", rev = "35b355e0bdfc52d37c7e93e814f54388d202dff1", features = ["clang_10_0"] }
 clap = { version = "4", features = ["derive"] }
 anyhow = "1"
 thiserror = "2"

--- a/README.md
+++ b/README.md
@@ -305,11 +305,54 @@ error: no structs matching '_PBE'
 
 Uses whatever version is available in your Developer Command Prompt environment.
 
-Covers **user-mode** headers (`windows.h`, `winternl.h`, `dbghelp.h`, crypto, networking, shell, COM, etc.) and **kernel-mode** headers (`ntddk.h`, `wdm.h`, `ntifs.h`, `fltkernel.h`, etc.)
+<details>
+<summary><b>User mode</b> — Win32 + COM IDL surface (click to expand)</summary>
+
+Winsock 2, networking (winhttp, wininet, iphlpapi, dhcpsapi, dns, ldap, snmp, ws2spi, http server, p2p alt, mprapi, rtmv2), security (acl, sddl, wincrypt, bcrypt, ncrypt, authz, wintrust, certenroll, cryptxml, slpublic, msdrm, winbio), shell/UI (shobjidl, shobjidl_core, commctrl, commdlg, uxtheme, dwmapi, magnification, prsht, interactioncontext, winwlx, highlevelmonitorconfigurationapi), GDI helpers (icm, fci), Media Foundation (mfapi, mfidl, mfreadwrite, mfmediaengine), Core Audio (mmdeviceapi, audioclient, audiopolicy), DirectShow (strmif, vfw), Direct3D 11/12 + DXGI 1.6 + d3dcompiler, UI Automation, Bluetooth, XInput, ETW + TraceLogging + TDH, BITS, Windows Update, MSI (msi, msiquery), Task Scheduler, DBGENG (debugger engine), AD (iads, adshlp, dsgetdc), PDH, WIA, WMP, COM+ (azroles, comsvcs, xpsobjectmodel, msinkaut, tom), virtdisk, fltuser (filter manager user side), peerdist, EAP (eapmethodpeerapis), WinUSB, projfs, WER, WMI consumers (wbemcli), Image helpers (traceloggingprovider, perflib), LM DFS, pathcch, traffic, sphelper (excluded — see notes), strsafe, intsafe, ntmsapi, mscat, drt, npapi, wdspxe / wdstpdi / wdsclientapi, roerrorapi, wtsapi32, lmaccess, setupapi, cfgmgr32, wlanapi + ras + rasdlg, powrprof, gpedit, oleauto, appmodel, hbaapi, propvarutil, propsys, traffic, mstcpip, windns, wincred, userenv, ktmw32, sapi, cfapi, diagnosticdataquery, clfsw32, usp10, winevt, …
+
+</details>
+
+<details>
+<summary><b>Kernel mode</b> — NT / WDF / NDIS / streaming (click to expand)</summary>
+
+Built on the `ntifs.h` umbrella (which transitively pulls `ntddk.h`, `wdm.h`, in the right order so `PEPROCESS` / `PETHREAD` don't redefine). On top of that: `ntstrsafe`, `wsk` (Winsock Kernel), `fltkernel` (minifilter), `aux_klib`, `usb` + `usbdi` + `usbdlib`, **WDF** (`wdf.h`, `wdfusb.h` — KMDF version auto-discovered from `Include/wdf/kmdf/<ver>/`), **NetAdapterCx** (modern NDIS-on-WDF — also version-discovered from `Include/<sdkver>/km/netcx/kmdf/adapter/<ver>/`), `ndis`, kernel streaming (`ks`, `ksmedia`, `portcls`), HID (`hidpi`, `hidclass`, `hidsdi`, `hidusage`), `swenum`, `pep_x`, `ndischimney`.
+
+</details>
+
+<details>
+<summary><b>Excluded (with rationale)</b></summary>
+
+Each is documented inline in `crates/bb-sdk/src/winsdk/{user,kernel}.rs`:
+
+- **storport.h** — `ntddstor.h` ships without include guards, so it re-runs all `DEFINE_GUID(GUID_DEVINTERFACE_*, …)` and clang flags redefinitions.
+- **d3dkmthk.h / bdasup.h / fwpsk.h / ksproxy.h** — drag in COM `wtypes.h` whose `VARENUM` / `VT_EMPTY` enumerators collide with the ones `ks.h` already declares.
+- **video.h / miniport.h** — miniport.h redefines `_QUAD` and `_PROCESSOR_NUMBER` against the kernel core types in scope.
+- **dbghelp.h (kernel)** — pulls `minidumpapiset.h` which needs user-mode-only types (`VS_FIXEDFILEINFO`, `TIME_ZONE_INFORMATION`).
+- **wdbgexts.h** — clang resolves `<wdbgexts.h>` from `um/` before `km/`, and the user-mode header uses `LPTR` which isn't defined in the kernel chain.
+- **bthsdpddi.h** — implicit-int header bug.
+- **dwrite.h / rtworkq.h** — use C++ syntax (`static_cast`, untagged interface names) that won't parse in C mode.
+- **sphelper.h** — heavy C++ speech-API templates that balloon clang parse time from ~9 s to >4 min.
+- **tapi.h chain (tapi3if, tspi, winfax)** — C-mode parse errors in tapi.h itself, cascading to everything that pulls it.
+- **webservices.h** — two empty enums clang rejects in C mode.
+- **wsman.h** — needs `WSMAN_API_VERSION_1_0` / `_1_1` defined first; not wired up.
+- **security.h / sspi.h** — needs `SECURITY_WIN32`/`SECURITY_KERNEL`/`SECURITY_MAC` defined first.
+- **p2p.h** — not in modern SDK (`10.0.26100.0`).
+- **winddi.h / rpcproxy.h** — `HSEMAPHORE` typedef conflict + anonymous-struct C-mode error.
+- **resapi.h / iscsidsc.h** — `PHANDLER_ROUTINE` redef vs services API + missing `ISDSC_STATUS` definition.
+- **imagehlp.h** — struct redefs against `dbghelp.h` (which is the modern superset).
+- **wudfddi.h** — only in legacy `wdf/umdf/1.x/` trees; modern UMDF 2.x uses `wdf.h` directly.
+- **ntsecapi.h** — `LSA_UNICODE_STRING` / `LSA_STRING` collide with `winternl.h`'s `UNICODE_STRING` / `STRING`.
+- **udecx.h** — not shipped in all installed WDKs.
+
+</details>
 
 ```
-bb-types --mode kernel --winsdk --struct *DRIVER_OBJECT*
+bb-types  --mode kernel --winsdk --struct *DRIVER_OBJECT*
+bb-funcs  --mode kernel --name NetAdapterCreate
+bb-funcs  --mode kernel --name WdfCollectionAdd
 ```
+
+All four mode combinations (`--mode user`, `--mode kernel`, `--phnt`, `--phnt --mode kernel`) parse with **zero libclang errors and zero warnings** against the SDK 10.0.26100.0 + WDK 1.35 + NetCx 2.5. Add `--diagnostics` to any invocation to see clang output yourself.
 
 </td>
 <td width="50%" valign="top">
@@ -325,9 +368,22 @@ bb-types --phnt win11 --struct _PEB
 bb-consts --phnt --name "STATUS_*"
 ```
 
+**PHNT mode auto-inherits the full Windows SDK umbrella** — `phnt_synthetic_header` starts from `winsdk::sdk_header(mode)` and only strips the two headers that fight `phnt.h` directly (`winternl.h` — phnt errors `Do not mix Winternl.h and phnt.h`; `winusb.h` — `shared/usb.h` stubs `PIRP=PVOID` against phnt's real `_IRP`). Every coverage expansion in `winsdk/` automatically applies to `--phnt`.
+
 </td>
 </tr>
 </table>
+
+### Header coverage
+
+Measured against the documented MSDN free-function surface that `bb-sparse` embeds (`sdk-api` for user mode, `windows-driver-docs-ddi` for kernel) — see `cargo test -p bb-tests sparse_coverage_dump -- --ignored --nocapture` to run it yourself. Interface methods aren't counted because `bb-funcs` filters on `EntityKind::FunctionDecl`, and IDL vtables surface those as function-pointer fields inside `IFoo::Vtbl` structs.
+
+| mode      | funcs  | types  | consts | enums | free-func coverage |
+|-----------|--------|--------|--------|-------|--------------------|
+| user      | 15,701 | 15,808 | 44,966 | 2,926 | 75.2%              |
+| kernel    |  4,884 |  3,298 | 19,893 |   735 | 62.4%              |
+| phnt user | 17,424 | 17,338 | 48,073 | 3,167 | —                  |
+| phnt kern |  4,885 |  3,721 | 20,472 |   776 | —                  |
 
 ---
 

--- a/crates/bb-sdk/src/config.rs
+++ b/crates/bb-sdk/src/config.rs
@@ -133,12 +133,18 @@ impl HeaderConfig {
     ///
     /// This includes:
     /// - Target triple for the architecture
-    /// - Include paths for SDK directories
+    /// - Include paths for SDK directories (and the newest installed WDF
+    ///   flavor matching the mode — KMDF for kernel, UMDF for user)
     /// - Architecture-specific preprocessor defines
+    /// - `KMDF_VERSION_MAJOR` / `KMDF_VERSION_MINOR` (or UMDF_*) defines when
+    ///   the matching WDF flavor is installed
     #[must_use]
     pub fn clang_args(&self) -> Vec<String> {
-        let (arch, sdk) = match self {
-            Self::WinSdk { arch, sdk, .. } | Self::Phnt { arch, sdk, .. } => (*arch, sdk),
+        let (arch, sdk, mode) = match self {
+            Self::WinSdk { arch, sdk, mode }
+            | Self::Phnt {
+                arch, sdk, mode, ..
+            } => (*arch, sdk, *mode),
         };
 
         let mut args = vec!["-target".into(), arch.target_triple().into()];
@@ -147,6 +153,36 @@ impl HeaderConfig {
         for subdir in ["shared", "um", "ucrt", "km"] {
             args.push("-I".into());
             args.push(sdk.get_include_dir().join(subdir).to_string_lossy().into());
+        }
+
+        // Add WDF include path + version defines for whichever flavor
+        // matches the mode. KMDF/UMDF have separate version namespaces.
+        let (flavor, prefix) = match mode {
+            crate::SdkMode::Kernel => ("kmdf", "KMDF"),
+            crate::SdkMode::User => ("umdf", "UMDF"),
+        };
+        if let Some(wdf) = sdk.wdf_latest(flavor) {
+            args.push("-I".into());
+            args.push(wdf.include_dir.to_string_lossy().into());
+            args.push(format!("-D{prefix}_VERSION_MAJOR={}", wdf.major));
+            args.push(format!("-D{prefix}_VERSION_MINOR={}", wdf.minor));
+        }
+
+        // NetAdapterCx (kernel only). Adds two include paths: the per-version
+        // public headers and the `shared/netcx/shared/<ver>/` tree that owns
+        // the `net/*.h` types. `netfuncenum.h` also requires NET_VERSION_*
+        // be defined before include.
+        if mode == crate::SdkMode::Kernel
+            && let Some(netcx) = sdk.netcx_latest()
+        {
+            args.push("-I".into());
+            args.push(netcx.include_dir.to_string_lossy().into());
+            args.push(format!("-DNET_VERSION_MAJOR={}", netcx.major));
+            args.push(format!("-DNET_VERSION_MINOR={}", netcx.minor));
+            if let Some(shared) = sdk.netcx_shared_dir() {
+                args.push("-I".into());
+                args.push(shared.to_string_lossy().into());
+            }
         }
 
         // Add architecture-specific defines

--- a/crates/bb-sdk/src/lib.rs
+++ b/crates/bb-sdk/src/lib.rs
@@ -24,7 +24,7 @@ pub use parser::{parse_phnt, parse_winsdk};
 pub use phnt::{PHNT_HEADER, PhntVersion, phnt_synthetic_header};
 
 // Windows SDK
-pub use winsdk::{SdkInfo, SdkMode, check_wdk_installed, get_sdk_info, sdk_header};
+pub use winsdk::{SdkInfo, SdkMode, WdfLocation, check_wdk_installed, get_sdk_info, sdk_header};
 
 // Re-export bb-clang types for convenience
 pub use bb_clang::{Field, FieldError, Struct, StructError};

--- a/crates/bb-sdk/src/phnt/kernel.rs
+++ b/crates/bb-sdk/src/phnt/kernel.rs
@@ -1,7 +1,0 @@
-//! Kernel-mode PHNT header configuration.
-
-/// Mode defines.
-pub(super) const DEFINES: &[(&str, &str)] = &[("_KERNEL_MODE", "1")];
-
-/// Base includes (provides base types from WDK).
-pub(super) const INCLUDES: &[&str] = &["ntdef.h"];

--- a/crates/bb-sdk/src/phnt/mod.rs
+++ b/crates/bb-sdk/src/phnt/mod.rs
@@ -1,8 +1,6 @@
 //! Module for working with PHNT from a developer command prompt environment.
 
-mod kernel;
-mod user;
-
+use crate::winsdk::{SdkMode, sdk_header};
 use clap::ValueEnum;
 
 /* ────────────────────────────────── Types ───────────────────────────────── */
@@ -90,28 +88,31 @@ const PHNT_INCLUDES: &[&str] = &["assert.h"];
 
 /// Generate a synthetic header that includes PHNT with the specified version.
 ///
-/// PHNT requires base Windows types (ULONG, `LIST_ENTRY`, PVOID, etc.) to be defined.
-/// We include the appropriate base header depending on mode:
-/// - User mode: `<windows.h>` provides all needed types
-/// - Kernel mode: `<ntdef.h>` from WDK provides base types
+/// PHNT mode = the same SDK umbrella as plain `--mode user` / `--mode kernel`
+/// (via [`sdk_header`]) with `PHNT_VERSION` plus the phnt.h superset on top.
+/// Coverage stays in sync with the winsdk groups.
 #[must_use]
 pub fn phnt_synthetic_header(version: PhntVersion, kernel_mode: bool) -> String {
     use std::fmt::Write;
 
-    let mut out = String::new();
-
-    if kernel_mode {
-        for &(name, value) in kernel::DEFINES {
-            let _ = writeln!(out, "#define {name} {value}");
-        }
-        for inc in kernel::INCLUDES {
-            let _ = writeln!(out, "#include <{inc}>");
-        }
+    let mode = if kernel_mode {
+        SdkMode::Kernel
     } else {
-        for inc in user::INCLUDES {
-            let _ = writeln!(out, "#include <{inc}>");
-        }
-    }
+        SdkMode::User
+    };
+
+    // Start with the full mode-appropriate SDK umbrella (defines + every
+    // group of public headers we curate in winsdk/{user,kernel}.rs), then
+    // strip a few headers that fight phnt.h directly:
+    //
+    // - `winternl.h`: phnt.h errors out with "Do not mix Winternl.h and
+    //   phnt.h" — its private NT API set is a superset of winternl's
+    //   redacted public surface.
+    // - `winusb.h`: pulls `shared/usb.h` whose stub `typedef PVOID PIRP`
+    //   conflicts with phnt's real `typedef struct _IRP *PIRP`.
+    let mut out = sdk_header(mode)
+        .replace("#include <winternl.h>\n", "")
+        .replace("#include <winusb.h>\n", "");
 
     let _ = writeln!(out, "#define PHNT_VERSION {}", version.macro_name());
 

--- a/crates/bb-sdk/src/phnt/user.rs
+++ b/crates/bb-sdk/src/phnt/user.rs
@@ -1,4 +1,0 @@
-//! User-mode PHNT header configuration.
-
-/// Base includes (provides ULONG, `LIST_ENTRY`, PVOID, etc.).
-pub(super) const INCLUDES: &[&str] = &["windows.h"];

--- a/crates/bb-sdk/src/winsdk/kernel.rs
+++ b/crates/bb-sdk/src/winsdk/kernel.rs
@@ -6,16 +6,32 @@ use super::HeaderGroup;
 pub(super) const GUARDED_DEFINES: &[(&str, &str)] = &[("NTDDI_VERSION", "WDK_NTDDI_VERSION")];
 
 /// Raw (unguarded) defines for kernel-mode.
-pub(super) const RAW_DEFINES: &[(&str, &str)] = &[("_KERNEL_MODE", "1")];
+///
+/// `CDECL` is normally defined by `shared/minwindef.h`, which only enters
+/// the include graph through `windows.h` (a user-mode header). Kernel
+/// chains don't pull it, so ks.h, ksmedia.h, and other shared headers
+/// that use `CDECL` as a calling-convention marker break without this.
+pub(super) const RAW_DEFINES: &[(&str, &str)] = &[
+    ("_KERNEL_MODE", "1"),
+    ("CDECL", "_cdecl"),
+    // mmreg.h would emit tagEXBMINFOHEADER (uses BITMAPINFOHEADER from
+    // wingdi.h) unless NOBITMAP gates it out. We pull mmreg.h only for
+    // its _INC_MMREG marker, not for the GDI structs.
+    ("NOBITMAP", ""),
+];
 
 /// Grouped `#include` sections for kernel-mode.
+///
+/// `ntifs.h` is the umbrella: it `#define`s `_NTIFS_` and pulls `ntddk.h`
+/// (which pulls `wdm.h`). Including `ntddk.h` before `ntifs.h` causes
+/// `PEPROCESS` / `PETHREAD` typedef redefinitions because `ntddk.h`
+/// emits forward typedefs that `ntifs.h` later redefines as full types.
+///
+/// Header set is chosen to cover as many of the documented kernel/driver
+/// DDIs from `bb-sparse`'s driver dataset as parse cleanly together.
 pub(super) const GROUPS: &[HeaderGroup] = &[
     HeaderGroup {
-        comment: "Core kernel headers",
-        includes: &["ntddk.h", "wdm.h"],
-    },
-    HeaderGroup {
-        comment: "File systems and more internal structures",
+        comment: "Core kernel headers (ntifs.h umbrella -> ntddk.h -> wdm.h)",
         includes: &["ntifs.h"],
     },
     HeaderGroup {
@@ -35,7 +51,70 @@ pub(super) const GROUPS: &[HeaderGroup] = &[
         includes: &["aux_klib.h"],
     },
     HeaderGroup {
-        comment: "Process/thread access",
-        includes: &["ntddk.h"],
+        comment: "USB DDK (must come before wdfusb.h: USB_REQUEST_*, PURB, USBD_STATUS)",
+        includes: &["usb.h", "usbdi.h"],
     },
+    HeaderGroup {
+        comment: "WDF / KMDF",
+        includes: &["wdf.h", "wdfusb.h"],
+    },
+    // Storage stack (storport.h, ata.h, classpnp.h) deliberately omitted:
+    // shared/ntddstor.h ships without include guards, and the ntifs.h
+    // chain has already pulled it in, so a second include via storport.h
+    // re-runs all `DEFINE_GUID(GUID_DEVINTERFACE_*, …)` lines and clang
+    // reports them as redefinitions.
+    HeaderGroup {
+        comment: "NDIS networking",
+        includes: &["ndis.h"],
+    },
+    HeaderGroup {
+        comment: "Kernel streaming + audio port-class",
+        // windef.h shims in BOOL/FLOAT/RECT for ks.h/ksmedia.h.
+        // mmreg.h sets _INC_MMREG, which gates KSDATAFORMAT_WAVEFORMATEX
+        // and friends in ksmedia.h — portcls.h needs those types.
+        includes: &["windef.h", "mmreg.h", "ks.h", "ksmedia.h", "portcls.h"],
+    },
+    HeaderGroup {
+        comment: "HID (hidusage.h provides USAGE for hidpi.h)",
+        includes: &["hidusage.h", "hidpi.h", "hidclass.h"],
+    },
+    HeaderGroup {
+        comment: "USB driver lib",
+        includes: &["usbdlib.h"],
+    },
+    HeaderGroup {
+        comment: "NetAdapterCx (modern NDIS-on-WDF)",
+        includes: &["netadaptercx.h"],
+    },
+    HeaderGroup {
+        comment: "Bus + power + debug extras (small driver DDIs)",
+        // wdbgexts.h omitted — clang resolves <wdbgexts.h> from `um/`
+        // before `km/` (the -I order), and the user-mode header uses
+        // LPTR which isn't defined in our kernel chain.
+        includes: &["swenum.h", "pep_x.h", "ndischimney.h"],
+    },
+    HeaderGroup {
+        comment: "HID driver-side",
+        includes: &["hidsdi.h"],
+    },
+    // bthsdpddi.h omitted — its top-level declarations rely on a typedef
+    // alias that isn't in scope (`implicit-int` errors at line 19).
+    // ucxclass.h / ucmcx.h / ucmucsicx.h / poscx.h are gated behind
+    // versioned KMDF-cousin paths (km/ucx/<ver>/, um/pos/<ver>/, …) that
+    // we don't discover yet. Their entries stay invisible until we add a
+    // generic discovery for those flavors.
+    // Deliberately omitted:
+    // - udecx.h: not present in all installed WDKs.
+    // - d3dkmthk.h / bdasup.h / fwpsk.h: drag in the COM machinery
+    //   (wtypes.h), which redefines VARENUM / VT_EMPTY against the
+    //   enumerators ks.h already declared for the kernel side.
+    // - video.h: references PEMULATOR_ACCESS_ENTRY / PBANKED_SECTION_ROUTINE
+    //   (typedef'd in miniport.h) but miniport.h itself redefines _QUAD and
+    //   _PROCESSOR_NUMBER against the kernel core types already in scope.
+    // - dbghelp.h: minidumpapiset.h needs user-mode-only types.
+    // dbghelp.h omitted: pulls minidumpapiset.h which references
+    // VS_FIXEDFILEINFO / TIME_ZONE_INFORMATION (user-mode-only types
+    // from winver.h / winbase.h). The driver dataset references it
+    // for only ~12 entries; the cost-vs-coverage trade-off favors
+    // leaving it for the dedicated user-mode path.
 ];

--- a/crates/bb-sdk/src/winsdk/mod.rs
+++ b/crates/bb-sdk/src/winsdk/mod.rs
@@ -32,6 +32,87 @@ impl SdkInfo {
     pub fn get_version(&self) -> &str {
         &self.version
     }
+
+    /// Locate the newest installed WDF flavor under this SDK's include dir.
+    ///
+    /// `flavor` is `"kmdf"` for kernel-mode WDF or `"umdf"` for user-mode.
+    /// The SDK lays them out under `Include/wdf/<flavor>/<major>.<minor>/`
+    /// (these are NOT under the per-SDK-version `Include/<sdk-ver>/` tree).
+    /// Returns `None` if no WDF of that flavor is installed.
+    #[must_use]
+    pub fn wdf_latest(&self, flavor: &str) -> Option<WdfLocation> {
+        // `Include/wdf/<flavor>` is a sibling of `Include/<sdk-ver>`, not a
+        // child — climb out of the version dir before joining `wdf`.
+        let root = self.include_dir.parent()?.join("wdf").join(flavor);
+        latest_versioned_dir(&root, "wdf.h")
+    }
+
+    /// Locate the newest installed `NetAdapterCx` tree under this SDK's
+    /// include dir. The layout differs from WDF — `NetCx` is laid out
+    /// *inside* the per-SDK-version `km/netcx/kmdf/adapter/<M>.<N>/`
+    /// (siblings, public headers) plus `shared/netcx/shared/1.0/net/`
+    /// (the `net/*.h` types netadaptercx.h depends on).
+    ///
+    /// Returns the path to add to the `-I` search list and the version
+    /// numbers; the shared/net path is reported via [`netcx_shared_dir`].
+    #[must_use]
+    pub fn netcx_latest(&self) -> Option<WdfLocation> {
+        let root = self
+            .include_dir
+            .join("km")
+            .join("netcx")
+            .join("kmdf")
+            .join("adapter");
+        latest_versioned_dir(&root, "netadaptercx.h")
+    }
+
+    /// Companion to [`netcx_latest`]: the `shared/netcx/shared/<ver>/`
+    /// directory that supplies `net/extension.h`, `net/ring.h`, etc.
+    /// Currently only `1.0` exists, but we still discover it.
+    #[must_use]
+    pub fn netcx_shared_dir(&self) -> Option<PathBuf> {
+        let root = self.include_dir.join("shared").join("netcx").join("shared");
+        latest_versioned_dir(&root, "net/extension.h").map(|loc| loc.include_dir)
+    }
+}
+
+/// Walk a directory of `<major>.<minor>/` subdirs and return the one
+/// containing `marker` with the highest version.
+fn latest_versioned_dir(root: &PathBuf, marker: &str) -> Option<WdfLocation> {
+    let mut best: Option<((u32, u32), PathBuf)> = None;
+    for entry in std::fs::read_dir(root).ok()?.flatten() {
+        let name = entry.file_name();
+        let Some(name_str) = name.to_str() else {
+            continue;
+        };
+        let Some((maj, min)) = name_str.split_once('.') else {
+            continue;
+        };
+        let (Ok(maj), Ok(min)) = (maj.parse::<u32>(), min.parse::<u32>()) else {
+            continue;
+        };
+        let path = entry.path();
+        if path.join(marker).exists() {
+            let v = (maj, min);
+            if best.as_ref().is_none_or(|(b, _)| v > *b) {
+                best = Some((v, path));
+            }
+        }
+    }
+    best.map(|((major, minor), include_dir)| WdfLocation {
+        include_dir,
+        major,
+        minor,
+    })
+}
+
+/// One installed WDF version (KMDF or UMDF) discovered under the SDK root.
+#[derive(Debug, Clone)]
+pub struct WdfLocation {
+    /// `…/Include/wdf/<flavor>/<major>.<minor>/`
+    pub include_dir: PathBuf,
+    pub major: u32,
+    pub minor: u32,
 }
 
 /* ──────────────────────────────── Utilities ─────────────────────────────── */
@@ -158,10 +239,15 @@ struct HeaderGroup {
     includes: &'static [&'static str],
 }
 
-/// Preamble includes shared across modes.
-const PREAMBLE_INCLUDES: &[&str] = &["sdkddkver.h"];
-
 /// Build a header string from structured components.
+///
+/// Order: guarded `#define`s, raw `#define`s, then grouped `#include`s.
+/// Defines must come first so they apply when each header chain is parsed;
+/// in particular, kernel-mode `sdkddkver.h` (pulled in transitively by
+/// `ntddk.h` → `ntdef.h`) sees `DECLSPEC_DEPRECATED_DDK` already defined
+/// by `ntdef.h` and so populates the `DECLSPEC_DEPRECATED_DDK_WINXP`
+/// family wdm.h depends on. Pulling `sdkddkver.h` in via a preamble
+/// `#include` ran it before `ntdef.h` and left those macros undefined.
 fn build_header(
     guarded_defines: &[(&str, &str)],
     raw_defines: &[(&str, &str)],
@@ -170,11 +256,6 @@ fn build_header(
     use std::fmt::Write;
 
     let mut out = String::new();
-
-    for inc in PREAMBLE_INCLUDES {
-        let _ = writeln!(out, "#include <{inc}>");
-    }
-    out.push('\n');
 
     for &(name, value) in guarded_defines {
         let _ = writeln!(out, "#ifndef {name}");

--- a/crates/bb-sdk/src/winsdk/user.rs
+++ b/crates/bb-sdk/src/winsdk/user.rs
@@ -11,14 +11,22 @@ pub(super) const GUARDED_DEFINES: &[(&str, &str)] = &[
 ];
 
 /// Grouped `#include` sections for user-mode.
+///
+/// `winsock2.h` / `ws2tcpip.h` must come **before** `windows.h` — the
+/// legacy `windows.h` chain pulls `winsock.h` (Winsock 1) which
+/// conflicts with the Winsock 2 declarations.
 pub(super) const GROUPS: &[HeaderGroup] = &[
+    HeaderGroup {
+        comment: "Winsock 2 (must precede windows.h)",
+        includes: &["winsock2.h", "ws2tcpip.h", "mswsock.h"],
+    },
     HeaderGroup {
         comment: "Core Windows",
         includes: &["windows.h", "winternl.h"],
     },
     HeaderGroup {
         comment: "Networking",
-        includes: &["winhttp.h", "wininet.h"],
+        includes: &["winhttp.h", "wininet.h", "iphlpapi.h", "icmpapi.h"],
     },
     HeaderGroup {
         comment: "Process/Thread/Memory",
@@ -44,6 +52,7 @@ pub(super) const GROUPS: &[HeaderGroup] = &[
             "wincrypt.h",
             "bcrypt.h",
             "ncrypt.h",
+            "authz.h",
         ],
     },
     HeaderGroup {
@@ -52,7 +61,7 @@ pub(super) const GROUPS: &[HeaderGroup] = &[
     },
     HeaderGroup {
         comment: "COM/OLE",
-        includes: &["objbase.h", "combaseapi.h"],
+        includes: &["objbase.h", "combaseapi.h", "oleauto.h"],
     },
     HeaderGroup {
         comment: "Debugging",
@@ -72,14 +81,264 @@ pub(super) const GROUPS: &[HeaderGroup] = &[
     },
     HeaderGroup {
         comment: "System Info",
-        includes: &["sysinfoapi.h", "powerbase.h"],
+        includes: &["sysinfoapi.h", "powerbase.h", "appmodel.h"],
     },
     HeaderGroup {
         comment: "Handles",
         includes: &["handleapi.h"],
     },
     HeaderGroup {
-        comment: "User/GDI (minimal)",
-        includes: &["winuser.h"],
+        comment: "User / GDI / common controls",
+        includes: &["winuser.h", "commctrl.h", "commdlg.h"],
+    },
+    HeaderGroup {
+        comment: "WTS / user-info",
+        // ntsecapi.h omitted — its LSA_UNICODE_STRING / LSA_STRING typedefs
+        // conflict with winternl.h's UNICODE_STRING / STRING.
+        includes: &["wtsapi32.h", "lmaccess.h"],
+    },
+    HeaderGroup {
+        comment: "Setup / Cfgmgr / WMI",
+        includes: &["setupapi.h", "cfgmgr32.h", "wbemcli.h"],
+    },
+    HeaderGroup {
+        comment: "Media Foundation",
+        includes: &["mfapi.h", "mfidl.h"],
+    },
+    HeaderGroup {
+        comment: "Core Audio (WASAPI / device enumeration / policy)",
+        includes: &["mmdeviceapi.h", "audioclient.h", "audiopolicy.h"],
+    },
+    HeaderGroup {
+        comment: "Direct3D (11/12) + DXGI",
+        includes: &["dxgi1_6.h", "d3d11.h", "d3d12.h"],
+    },
+    HeaderGroup {
+        comment: "Shell objects (COM)",
+        includes: &["shobjidl_core.h", "shobjidl.h"],
+    },
+    HeaderGroup {
+        comment: "UI Automation",
+        includes: &["uiautomation.h"],
+    },
+    HeaderGroup {
+        comment: "Bluetooth + XInput",
+        includes: &["bluetoothapis.h", "xinput.h"],
+    },
+    HeaderGroup {
+        comment: "ETW / TDH tracing",
+        includes: &["evntrace.h", "evntprov.h", "tdh.h"],
+    },
+    HeaderGroup {
+        comment: "Background transfer (BITS) + Windows Update",
+        includes: &["bits.h", "wuapi.h"],
+    },
+    HeaderGroup {
+        comment: "Certificate enrollment",
+        includes: &["certenroll.h"],
+    },
+    HeaderGroup {
+        comment: "DirectShow",
+        includes: &["strmif.h"],
+    },
+    // TAPI omitted — tapi3if.h pulls tapi.h, which has C-mode parse errors.
+    HeaderGroup {
+        comment: "Windows Image Acquisition",
+        includes: &["wia.h"],
+    },
+    HeaderGroup {
+        comment: "Windows Media Player",
+        includes: &["wmp.h"],
+    },
+    HeaderGroup {
+        comment: "AzMan / COM+ / XPS / Tablet ink / TextObjectModel",
+        includes: &[
+            "azroles.h",
+            "comsvcs.h",
+            "xpsobjectmodel.h",
+            "msinkaut.h",
+            "tom.h",
+        ],
+    },
+    HeaderGroup {
+        comment: "Active Directory",
+        includes: &["iads.h", "adshlp.h"],
+    },
+    HeaderGroup {
+        comment: "Performance counters",
+        includes: &["pdh.h"],
+    },
+    HeaderGroup {
+        comment: "Task Scheduler",
+        includes: &["taskschd.h"],
+    },
+    HeaderGroup {
+        comment: "Text services framework / performance logs",
+        // dwrite.h omitted — uses C++ syntax (`static_cast`, untagged
+        // struct references) that won't parse in C mode.
+        includes: &["msctf.h", "pla.h"],
+    },
+    HeaderGroup {
+        comment: "Property variants + intsafe helpers",
+        includes: &["propvarutil.h", "intsafe.h"],
+    },
+    HeaderGroup {
+        comment: "LDAP / firewall (netfw, fwpmu)",
+        // webservices.h omitted — declares two empty enums clang rejects in C mode.
+        includes: &["winldap.h", "netfw.h", "fwpmu.h"],
+    },
+    HeaderGroup {
+        comment: "Video for Windows / IMAPI / Failover Cluster / Management Infra",
+        includes: &["vfw.h", "imapi2.h", "clusapi.h", "mi.h"],
+    },
+    HeaderGroup {
+        comment: "Debugger engine (dbgeng) — user-mode debugging",
+        includes: &["dbgeng.h"],
+    },
+    // wudfddi.h omitted — lives only in legacy `wdf/umdf/1.x/` trees that
+    // aren't on the include path; modern UMDF 2.x uses wdf.h directly.
+    HeaderGroup {
+        comment: "MF read/write + media engine + D3D compiler",
+        includes: &["mfreadwrite.h", "mfmediaengine.h", "d3dcompiler.h"],
+    },
+    HeaderGroup {
+        comment: "Property system",
+        includes: &["propsys.h"],
+    },
+    HeaderGroup {
+        comment: "WLAN + RAS",
+        includes: &["wlanapi.h", "ras.h", "rasdlg.h"],
+    },
+    HeaderGroup {
+        comment: "Power + Group Policy",
+        includes: &["powrprof.h", "gpedit.h"],
+    },
+    // security.h omitted — its inner `sspi.h` requires one of
+    // SECURITY_WIN32 / SECURITY_KERNEL / SECURITY_MAC be defined first.
+    // We don't currently expose a place to set that per-mode.
+    HeaderGroup {
+        comment: "DHCP / DNS / MSTCPIP",
+        includes: &["dhcpsapi.h", "dhcpcsdk.h", "windns.h", "mstcpip.h"],
+    },
+    HeaderGroup {
+        comment: "MSI (installer)",
+        includes: &["msi.h", "msiquery.h"],
+    },
+    HeaderGroup {
+        comment: "MPRAPI + RTMv2",
+        // p2p.h omitted — not shipped in modern SDK trees.
+        includes: &["mprapi.h", "rtmv2.h"],
+    },
+    HeaderGroup {
+        comment: "HBA",
+        // tapi.h / tspi.h omitted — tapi.h has C-mode parse errors that
+        // cascade into anything that pulls it (tspi.h, winfax.h, tapi3if.h).
+        includes: &["hbaapi.h"],
+    },
+    HeaderGroup {
+        comment: "NTMS",
+        // resapi.h omitted — typedef redefinition of PHANDLER_ROUTINE
+        // (PVOID vs DWORD_PTR) against services API.
+        // iscsidsc.h omitted — references ISDSC_STATUS without including
+        // the header that defines it.
+        includes: &["ntmsapi.h"],
+    },
+    HeaderGroup {
+        comment: "Theming + DWM + Direct Composition",
+        includes: &["uxtheme.h", "dwmapi.h"],
+    },
+    HeaderGroup {
+        comment: "Strsafe + SafeInt helpers",
+        includes: &["strsafe.h"],
+    },
+    HeaderGroup {
+        comment: "HTTP server / WinSNMP / WinCred / Userenv",
+        // winfax.h omitted — pulls tapi.h transitively.
+        includes: &["http.h", "winsnmp.h", "wincred.h", "userenv.h"],
+    },
+    HeaderGroup {
+        comment: "ICM (color management) + NTDS",
+        includes: &["icm.h", "ntdsapi.h"],
+    },
+    HeaderGroup {
+        comment: "Common log file system + USP10",
+        includes: &["clfsw32.h", "usp10.h"],
+    },
+    HeaderGroup {
+        comment: "DRM",
+        // winddi.h omitted — pulls ddrawi.h -> dvp.h whose typedefs collide
+        // with the chain; also redefines HSEMAPHORE against the GDI version.
+        // rpcproxy.h omitted — uses anonymous struct declarations clang
+        // rejects in C mode.
+        includes: &["msdrm.h"],
+    },
+    HeaderGroup {
+        comment: "Biometrics + Software Licensing + WSA SPI + Event Log",
+        includes: &["winbio.h", "slpublic.h", "ws2spi.h", "winevt.h"],
+    },
+    HeaderGroup {
+        comment: "KTM / WER / SAPI / Cloud Files / Diagnostic Data",
+        includes: &[
+            "ktmw32.h",
+            "werapi.h",
+            "sapi.h",
+            "cfapi.h",
+            "diagnosticdataquery.h",
+        ],
+    },
+    HeaderGroup {
+        comment: "Property sheets + SNMP + WDS client",
+        includes: &["prsht.h", "snmp.h", "wdsclientapi.h"],
+    },
+    HeaderGroup {
+        comment: "WinUSB",
+        // wsman.h omitted — requires `WSMAN_API_VERSION_1_0` or `_1_1`
+        // be defined before include; not wired up.
+        includes: &["winusb.h"],
+    },
+    HeaderGroup {
+        comment: "Virtual disk + Filter Manager user / Catalog / Peer Dist / DRT",
+        includes: &["virtdisk.h", "fltuser.h", "mscat.h", "peerdist.h", "drt.h"],
+    },
+    HeaderGroup {
+        comment: "Network providers + EAP + Interaction context + WDS PXE",
+        // rtworkq.h omitted — uses C++ syntax (untagged interface names).
+        includes: &[
+            "npapi.h",
+            "eapmethodpeerapis.h",
+            "interactioncontext.h",
+            "wdspxe.h",
+        ],
+    },
+    HeaderGroup {
+        comment: "Trace logging / DS / Perf",
+        // imagehlp.h omitted — its `_LOADED_IMAGE`, `_MODLOAD_DATA` etc.
+        // collide with dbghelp.h (which is the modern superset).
+        includes: &["traceloggingprovider.h", "dsgetdc.h", "perflib.h"],
+    },
+    HeaderGroup {
+        comment: "LM DFS / Pathcch / WinWlx / High-level monitor / Traffic",
+        includes: &[
+            "lmdfs.h",
+            "pathcch.h",
+            "winwlx.h",
+            "highlevelmonitorconfigurationapi.h",
+            "traffic.h",
+        ],
+    },
+    HeaderGroup {
+        comment: "Magnification / ProjFS / RO error / WDS TP",
+        includes: &[
+            "magnification.h",
+            "projectedfslib.h",
+            "roerrorapi.h",
+            "wdstpdi.h",
+        ],
+    },
+    HeaderGroup {
+        comment: "FCI / WinTrust / CryptXML",
+        // sphelper.h omitted — heavy C++ speech-API templates that
+        // balloon clang parse time from ~9s to >4 minutes.
+        includes: &["fci.h", "wintrust.h", "cryptxml.h"],
     },
 ];

--- a/crates/bb-sparse/src/lib.rs
+++ b/crates/bb-sparse/src/lib.rs
@@ -437,3 +437,21 @@ pub fn entry_count_sdk() -> usize {
 pub fn entry_count_driver() -> usize {
     driver_lookup().len()
 }
+
+/// Iterate over every embedded SDK entry as `(name, metadata)`.
+///
+/// Order is HashMap-arbitrary. Useful for harvesting the full set of
+/// headers / libs that documented user-mode APIs live in, or for
+/// computing coverage against a parsed translation unit.
+pub fn iter_sdk() -> impl Iterator<Item = (&'static str, &'static SdkMetadata)> {
+    sdk_lookup().iter().map(|(k, v)| (k.as_str(), v))
+}
+
+/// Iterate over every embedded driver entry as `(name, metadata)`.
+///
+/// Order is HashMap-arbitrary. Useful for harvesting the full set of
+/// `include-header` values that documented kernel-mode / KMDF / UMDF
+/// DDIs live in.
+pub fn iter_driver() -> impl Iterator<Item = (&'static str, &'static DriverMetadata)> {
+    driver_lookup().iter().map(|(k, v)| (k.as_str(), v))
+}

--- a/tests/src/sparse.rs
+++ b/tests/src/sparse.rs
@@ -13,6 +13,125 @@
 
 use bb_sparse::{Entry, Metadata};
 
+/* ─────────── One-off coverage probe (not part of CI) ──────────────────────
+ *
+ * Run with:
+ *   cargo test -p bb-tests sparse_coverage_dump -- --ignored --nocapture --test-threads=1
+ *
+ * For each sparse entry whose header is known, ask bb-funcs whether it's
+ * visible in the current default bb-sdk umbrella (parsed via the standard
+ * config + the macro-preprocessed TU). Aggregate misses by header to show
+ * where the next batch of `bb-sdk` header additions would pay off.
+ */
+
+#[test]
+#[ignore]
+fn sparse_coverage_dump() -> anyhow::Result<()> {
+    use bb_sdk::{Arch, HeaderConfig, SdkMode};
+    use clang::{Clang, EntityKind, Index};
+    use std::collections::{BTreeMap, HashSet};
+
+    fn collect_visible(mode: SdkMode) -> HashSet<String> {
+        let cfg = HeaderConfig::winsdk(Arch::Amd64, mode).expect("sdk");
+        let clang = Clang::new().unwrap();
+        let index = Index::new(&clang, false, false);
+        let tu = cfg.parse(&index, true).expect("parse");
+        let mut names = HashSet::new();
+        for e in tu.get_entity().get_children() {
+            if matches!(e.get_kind(), EntityKind::FunctionDecl)
+                && let Some(n) = e.get_name()
+            {
+                names.insert(n);
+            }
+        }
+        names
+    }
+
+    fn report(
+        label: &str,
+        visible: &HashSet<String>,
+        iter: impl Iterator<Item = (String, String)>,
+    ) {
+        let mut per_header: BTreeMap<String, (usize, usize, usize)> = BTreeMap::new();
+        let mut total_have = 0usize;
+        let mut total_miss_method = 0usize;
+        let mut total_miss_other = 0usize;
+        let mut sample_other: Vec<(String, String)> = Vec::new();
+        for (name, header) in iter {
+            let key = header
+                .split(',')
+                .next()
+                .unwrap_or(&header)
+                .trim()
+                .to_ascii_lowercase();
+            let entry = per_header.entry(key.clone()).or_insert((0, 0, 0));
+            if visible.contains(&name) {
+                entry.0 += 1;
+                total_have += 1;
+            } else if name.contains("::") {
+                entry.1 += 1;
+                total_miss_method += 1;
+            } else {
+                entry.2 += 1;
+                total_miss_other += 1;
+                if sample_other.len() < 40 {
+                    sample_other.push((name, key));
+                }
+            }
+        }
+        let total = total_have + total_miss_method + total_miss_other;
+        println!("===== {label} =====");
+        println!("  have:       {total_have}");
+        println!("  miss (::):  {total_miss_method}   <- COM interface methods");
+        println!("  miss (free):{total_miss_other}   <- actual free-function misses");
+        println!(
+            "  ratio incl. methods: {:.1}%",
+            100.0 * total_have as f64 / total.max(1) as f64
+        );
+        println!(
+            "  ratio free-only:     {:.1}%",
+            100.0 * total_have as f64 / (total_have + total_miss_other).max(1) as f64
+        );
+        let mut rows: Vec<_> = per_header.into_iter().collect();
+        rows.sort_by(|a, b| b.1.2.cmp(&a.1.2));
+        println!("Top headers by free-function miss:");
+        println!(
+            "{:<32}{:>8}{:>10}{:>10}",
+            "header", "have", "miss(::)", "miss(free)"
+        );
+        for (h, (have, method_miss, free_miss)) in rows.iter().take(40) {
+            if *free_miss == 0 {
+                continue;
+            }
+            println!("{h:<32}{have:>8}{method_miss:>10}{free_miss:>10}");
+        }
+        println!("Sample of free-function misses (name <- header):");
+        for (n, h) in sample_other.iter().take(30) {
+            println!("  {n:<40} {h}");
+        }
+    }
+
+    let visible_user = collect_visible(SdkMode::User);
+    report(
+        "USER vs sparse SDK",
+        &visible_user,
+        bb_sparse::iter_sdk()
+            .filter_map(|(name, m)| m.header_str().map(|h| (name.to_string(), h.to_string()))),
+    );
+
+    let visible_kernel = collect_visible(SdkMode::Kernel);
+    report(
+        "KERNEL vs sparse driver",
+        &visible_kernel,
+        bb_sparse::iter_driver().filter_map(|(name, m)| {
+            m.include_header_str()
+                .map(|h| (name.to_string(), h.to_string()))
+        }),
+    );
+
+    Ok(())
+}
+
 /* ───────────────────────────── Smoke invariants ─────────────────────────── */
 
 #[test]


### PR DESCRIPTION
Closes #16.

Replaces the small curated user / kernel header sets with a much larger, diagnostic-clean superset, switches to tracking clang-rs upstream master (instead of the abandoned crates.io 2.0.0), and resyncs PHNT mode on top of the winsdk umbrella.

## clang-rs upstream

Switched `clang = "2.0.0"` (crates.io) to `git rev 35b355e0` — KyleMayes/clang-rs master. The crates.io release reads uninitialized memory for the token-array pointer when `clang_tokenize` writes `count == 0`, which Rust 1.78+'s `slice::from_raw_parts` UB-precondition check turns into a non-unwinding abort. Upstream master null-checks the out-pointer. Removes the previous workaround helper from bb-clang.

## winsdk header generation

- **Defines now emit BEFORE the preamble include order.** Resolves the pre-existing cascade of `DECLSPEC_DEPRECATED_DDK_WINXP` errors in kernel mode: `sdkddkver.h` was parsed before `ntdef.h` got a chance to define `DECLSPEC_DEPRECATED_DDK`, so sdkddkver.h's `#if defined(DECLSPEC_DEPRECATED_DDK)` block skipped its DDK-family macro definitions entirely.
- **Kernel umbrella switched** from `ntddk.h, wdm.h` + `ntifs.h` to just `ntifs.h` (which gates `_NTIFS_` and pulls the rest in the right order). The old combo redefined `PEPROCESS` / `PETHREAD` because ntddk.h emits forward typedefs that ntifs.h later redefines as full types.
- **New raw kernel defines**: `CDECL=_cdecl` (so shared headers ks.h, ksmedia.h, portcls.h work without pulling user-mode `minwindef.h`); `NOBITMAP` (gates out `tagEXBMINFOHEADER` in mmreg.h that references GDI's `BITMAPINFOHEADER`).

## Versioned include trees (WDF + NetAdapterCx)

The SDK ships KMDF / UMDF and NetAdapterCx under per-version subtrees sibling to `Include/<sdkver>/`. `HeaderConfig::clang_args` now:

- Discovers the newest installed KMDF (kernel) or UMDF (user) under `Include/wdf/<flavor>/<M>.<N>/` and emits both `-I` and `-D<flavor>_VERSION_MAJOR=…` / `-D…_VERSION_MINOR=…`.
- Discovers the newest installed NetAdapterCx under `Include/<sdkver>/km/netcx/kmdf/adapter/<M>.<N>/` plus the `shared/netcx/shared/<ver>/net/*.h` types tree, and emits `-DNET_VERSION_*`.

New public type `WdfLocation` on the crate boundary.

## PHNT resync

`phnt_synthetic_header(mode, version)` now starts from `winsdk::sdk_header(mode)` (the full curated umbrella) and only strips the two headers that fight `phnt.h` directly:

- `winternl.h` — phnt errors `Do not mix Winternl.h and phnt.h`.
- `winusb.h` — pulls `shared/usb.h` whose stub `typedef PVOID PIRP` collides with phnt's real `typedef struct _IRP *PIRP`.

The old `phnt/{kernel,user}.rs` per-mode include lists are deleted. PHNT now auto-inherits every coverage expansion from the winsdk groups.

## bb-sparse public iteration API

```rust
pub fn iter_sdk()    -> impl Iterator<Item = (&'static str, &'static SdkMetadata)>;
pub fn iter_driver() -> impl Iterator<Item = (&'static str, &'static DriverMetadata)>;
```

Yields `(name, metadata)` so callers can compute coverage against a parsed translation unit. A `#[test] #[ignore]` `sparse_coverage_dump` uses the iter API to probe which sparse entries are actually visible via bb-funcs's `FunctionDecl` filter, splitting misses into COM interface methods (name contains `::`) vs free-function misses. Invoke:

```
cargo test -p bb-tests sparse_coverage_dump -- --ignored --nocapture --test-threads=1
```

## Header set expansion

Big batches of clean-parsing headers added across user and kernel modes (Media Foundation, Core Audio, Direct3D 11/12, WDF, NDIS, Bluetooth, ETW + TraceLogging, BITS, Task Scheduler, Active Directory, NetAdapterCx, kernel streaming, HID, USB DDK, debugger engine, …). Each excluded header is documented inline in `crates/bb-sdk/src/winsdk/{user,kernel}.rs` with the reason (COM-vs-ks `VARENUM` collision, missing -I path, C++ syntax in C mode, missing required defines, etc.). See the README ["Header coverage"](README.md#header-coverage) section for the full lists.

## Growth

All v0.2.1-rev3 numbers measured against the same SDK (10.0.26100.0 + WDK 1.35 + NetCx 2.5) via `--winsdk --json --name "*"` and `bb-types --json --struct "*"` / `bb-consts --json --name "*"`:

| mode      | metric  | v0.2.1-rev3 | HEAD   | Δ%      |
|-----------|---------|-------------|--------|---------|
| user      | funcs   |       8,154 | 15,701 | **+92.6%**  |
| user      | types   |       4,986 | 15,808 | **+217%**   |
| user      | consts  |      25,371 | 44,966 | **+77.2%**  |
| user      | enums   |         654 |  2,926 | **+347%**   |
| kernel    | funcs   |       3,643 |  4,884 | **+34.1%**  |
| kernel    | types   |       1,804 |  3,298 | **+82.8%**  |
| kernel    | consts  |      11,322 | 19,893 | **+75.7%**  |
| kernel    | enums   |         366 |    735 | **+100.8%** |

PHNT mode (no equivalent v0.2.1 baseline because it didn't share the winsdk header set): user `17,424 funcs / 17,338 types / 48,073 consts / 3,167 enums`, kernel `4,885 funcs / 3,721 types / 20,472 consts / 776 enums`.

## Sparse-vs-actual free-function coverage

- **user: 75.2%** (12,505 of 16,631 documented free funcs visible)
- **kernel: 62.4%** (2,917 of 4,676 documented free funcs visible)

COM interface methods (names containing `::`) are excluded — bb-funcs filters on `EntityKind::FunctionDecl`, so vtable function-pointer fields aren't counted here. That requires a separate vtable-aware enumeration path; tracked in #19 alongside a TU/PCH parse cache for warm-start CLI invocations.

## Test plan

- [x] `cargo build --workspace` clean
- [x] `cargo test --workspace -- --test-threads=1`: **130 passed, 1 ignored** (the coverage probe)
- [x] `cargo fmt --all` + `cargo clippy --fix --workspace --all-targets` with default lints **AND** `clippy::pedantic` + `clippy::nursery`
- [x] `bb-funcs --mode user   --diagnostics --name __nonexistent`: **0 errors, 0 warnings**
- [x] `bb-funcs --mode kernel --diagnostics --name __nonexistent`: **0 errors, 0 warnings**
- [x] `bb-funcs --phnt Win11-22H2             --diagnostics --name __nonexistent`: **0 errors, 0 warnings**
- [x] `bb-funcs --phnt Win11-22H2 --mode kernel --diagnostics --name __nonexistent`: **0 errors, 0 warnings**
- [x] Spot checks: `GetAddrInfoExW`, `NetAdapterCreate`, `WdfCollectionAdd`, `NdisAllocateMemory`, `PcAddAdapterDevice`, `CreateFileW`, `MFCreateMediaType` all resolve.

## Follow-up

- #19 — cache parsed translation units via `clang_saveTranslationUnit` / `-emit-pch` so repeat CLI invocations skip the ~9 s parse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)