### PR TITLE
feat: typedef resolution + Union type + anon-record JSON (closes #14)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,6 +25,34 @@ jobs:
       - name: Set up MSVC environment
         uses: ilammy/msvc-dev-cmd@v1
 
+      - name: Install Windows Driver Kit (WDK)
+        shell: pwsh
+        run: |
+          # WDK provides kernel-mode headers (km/ntddk.h and friends)
+          # under Windows Kits\10\Include\<sdk-ver>\km\. The
+          # windows-latest image ships the SDK but not the WDK, so
+          # bb-sdk's `check_wdk_installed` flags kernel-mode parsing
+          # paths as unavailable. Install via winget so the kernel
+          # integration tests can actually parse those headers.
+          Write-Host "::group::winget install Microsoft.WindowsWDK.10.0.22621"
+          winget install `
+            --id Microsoft.WindowsWDK.10.0.22621 `
+            --silent `
+            --accept-source-agreements `
+            --accept-package-agreements `
+            --disable-interactivity
+          Write-Host "::endgroup::"
+
+          # Verify km/ntddk.h showed up somewhere clang can find it.
+          $ntddk = Get-ChildItem `
+            -Path 'C:\Program Files (x86)\Windows Kits\10\Include\*\km\ntddk.h' `
+            -ErrorAction SilentlyContinue | Select-Object -First 1
+          if (-not $ntddk) {
+            Write-Error "WDK install verification failed — no km/ntddk.h found under Windows Kits\10\Include\."
+            exit 1
+          }
+          Write-Host "WDK installed: $($ntddk.FullName)"
+
       - name: Install uv
         uses: astral-sh/setup-uv@v5
         with:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -108,9 +108,12 @@ Tests use `serial_test` because libclang is not fully thread-safe. Integration t
 - **`Param::is_stack()`** and **`Param::size()`** are methods on the Param type for ABI queries.
 - **`entity_in_header()`** in `bb-clang/location.rs` is the shared header-matching helper used by all filter structs.
 - **`bb_cli::current_command_string()`** is used by all CLIs for JSON `"command"` fields.
-- **`format_abi_param()`** in `bb-clang/display/function.rs` is the shared ABI row formatter.
+- **`format_abi_param()`** in `bb-clang/display/function.rs` is the shared ABI row formatter. Takes an optional `&TypedefIndex` so typedef'd param types render with a dim `(canonical)` annotation (e.g. `HANDLE (void *)`).
 - **`format_tags()`** returns `Vec<String>` so callers can extend before joining.
 - **`TypeInfo`** in `bb-clang/type_info.rs` is the shared type metadata struct embedded (via `#[serde(flatten)]`) in both `Field` and `Param`. Constructed via `From<clang::Type>`. Exposes `underlying_type`, `is_const`, `is_volatile`, `is_restrict`, `is_pointer`, `pointer_depth`, `is_function_pointer`, `is_array`, `array_size`.
+- **`TypedefIndex`** in `bb-clang/typedef.rs` is a translation-unit-scoped map of every `EntityKind::TypedefDecl`. Each `Typedef` entry carries the alias name, the immediate target (`typedef_of`), the resolved canonical form (`canonical`), the optional `canonical_decl_name` (when the chain ends at a named record/enum), the full `chain` of intermediate steps, and a `TypedefKind` classification (`struct`, `union`, `enum`, `pointer`, `function_pointer`, `array`, `primitive`, `other`). Drives (1) alias-aware struct lookup in `bb-types`, (2) the `aliases: [...]` field on `Struct` JSON, (3) typedef-only hit reporting (`HANDLE`, `PVOID`), (4) the dim `(canonical)` annotation in CLI/TUI field & param renderers via `display::typedef_annotation`.
+- **`Struct`** accepts `StructDecl`, `ClassDecl`, **and `UnionDecl`** (unions are modeled with overlapping field offsets — needed for `LARGE_INTEGER` and friends).
+- **`Struct::display(depth, field_filter, typedef_index)`** takes an optional `&TypedefIndex` to drive header `[aka …]` aliases and inline field-type annotations. `Function::display_detail(typedef_index)` mirrors this for ABI rows + return type.
 - **bb-funcs `enriched` module** owns the sparse metadata rendering. Enriched JSON is composed by starting from `p.to_json()` / `f.to_json()` and extending with sparse metadata. bb-clang stays generic.
 - **bb-funcs `where_filter` module** evaluates SQL WHERE clauses via `bb-sql::Evaluator`.
 - **`bb_cli::terminal_width()`** is the shared terminal width helper used by all CLIs.
@@ -123,6 +126,7 @@ Tests use `serial_test` because libclang is not fully thread-safe. Integration t
 | `function/abi.rs` | Calling conventions + ABI parameter assignment engine |
 | `function/param.rs` | Param type with `is_stack()`, `size()`, embeds `TypeInfo` |
 | `type_info.rs` | Shared `TypeInfo` struct: type classification (pointer, array, const, volatile, function pointer, underlying type) |
+| `typedef.rs` | `TypedefIndex` / `Typedef` / `TypedefKind`: translation-unit-scoped typedef resolution (alias name → canonical form + chain + kind) |
 | `constant/tokens.rs` | Clang ↔ cexpr token conversion |
 | `constant/macro_.rs` | Macro resolution with identifier substitution |
 | `ext.rs` | Extension traits for clang types (`UnderlyingType`, `AnonymousType`, etc.) |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,7 +14,7 @@ The project runs on Windows only (requires MSVC build tools + libclang.dll).
 bb/
 ├── crates/              # Libraries (never produce binaries)
 │   ├── bb-arch          # Architecture enums, registers, ABI location types, JSON serialization
-│   ├── bb-clang         # libclang abstractions: Struct, Enum, Constant, Function, Param, TypeInfo
+│   ├── bb-clang         # libclang abstractions: Struct, Union, Enum, Constant, Function, Param, TypeInfo, RecordKind, AnonRef
 │   ├── bb-cli           # Shared CLI args (SharedArgs), suggestions, terminal_width, helpers
 │   ├── bb-sdk           # Windows SDK + PHNT header config, parsing, architecture defines
 │   ├── bb-shared         # Tiny utilities: glob_match, levenshtein, suggest_closest
@@ -112,8 +112,12 @@ Tests use `serial_test` because libclang is not fully thread-safe. Integration t
 - **`format_tags()`** returns `Vec<String>` so callers can extend before joining.
 - **`TypeInfo`** in `bb-clang/type_info.rs` is the shared type metadata struct embedded (via `#[serde(flatten)]`) in both `Field` and `Param`. Constructed via `From<clang::Type>`. Exposes `underlying_type`, `is_const`, `is_volatile`, `is_restrict`, `is_pointer`, `pointer_depth`, `is_function_pointer`, `is_array`, `array_size`.
 - **`TypedefIndex`** in `bb-clang/typedef.rs` is a translation-unit-scoped map of every `EntityKind::TypedefDecl`. Each `Typedef` entry carries the alias name, the immediate target (`typedef_of`), the resolved canonical form (`canonical`), the optional `canonical_decl_name` (when the chain ends at a named record/enum), the full `chain` of intermediate steps, and a `TypedefKind` classification (`struct`, `union`, `enum`, `pointer`, `function_pointer`, `array`, `primitive`, `other`). Drives (1) alias-aware struct lookup in `bb-types`, (2) the `aliases: [...]` field on `Struct` JSON, (3) typedef-only hit reporting (`HANDLE`, `PVOID`), (4) the dim `(canonical)` annotation in CLI/TUI field & param renderers via `display::typedef_annotation`.
-- **`Struct`** accepts `StructDecl`, `ClassDecl`, **and `UnionDecl`** (unions are modeled with overlapping field offsets — needed for `LARGE_INTEGER` and friends).
-- **`Struct::display(depth, field_filter, typedef_index)`** takes an optional `&TypedefIndex` to drive header `[aka …]` aliases and inline field-type annotations. `Function::display_detail(typedef_index)` mirrors this for ABI rows + return type.
+- **`Struct` vs `Union` are strictly separate types** since the Item-5 refactor. `Struct::try_from` accepts only `StructDecl` / `ClassDecl`; `Union::try_from` accepts only `UnionDecl`. Both carry `kind: RecordKind` (`Struct` / `Union`) for symmetric JSON dispatch. Top-level union typedefs like `LARGE_INTEGER` are findable via `collect_unions` and the `find_union_by_name` lib helper (parallels `collect_structs` / `find_struct_by_name`). Anonymous nested unions never appear at the TU root — they surface only inside their parent record's member list.
+- **`record.rs`** holds the shared `RecordKind` enum and the `AnonRef { kind, enclosing_record, field_path }` cross-reference used by anonymous nested records to point into the parent record's `referenced_types` slot.
+- **Anonymous nested records are synthesized as `Field` entries**. Under default MSVC parsing the `DUMMYUNIONNAME`/`DUMMYSTRUCTNAME` macros expand to empty, so clang represents the inner union as a `UnionDecl` *sibling* of the parent struct's FieldDecls — no `FieldDecl` wrapping. `build_anon_record_field` in `struct_/field.rs` synthesizes a `Field` for that decl with synthetic name `<anonymous_N>` (per-parent counter, separate counters for nameless FieldDecls vs sibling record decls), `is_anonymous: true`, an `anon_ref`, and an offset computed by `anon_record_offset_in_parent` (asks the parent's type for the offset of any reachable named member). The synthetic Field's `entity` is the record decl itself; `Field::get_field_decl()` returns `None` for these (real fields return `Some`).
+- **JSON shape: single `referenced_types` slot**. `Struct` / `Union` JSON outputs collapse into a uniform shape: `to_json` adds `referenced_types` as a name-string list of named referenced records; `to_json_full` adds it as full objects (named + anonymous, distinguished by per-entry `"kind"`). The mixed-record helper `bb_clang::records_to_json_full(structs, unions)` produces the top-level `{ types, referenced_types }` envelope shared by struct + union queries. The `bb-types` CLI wraps that with `command` and `typedefs`.
+- **`Struct::display(depth, field_filter, typedef_index)`** takes an optional `&TypedefIndex` to drive header `[aka …]` aliases and inline field-type annotations. `Union::display(...)` mirrors it. `Function::display_detail(typedef_index)` is analogous for ABI rows + return type.
+- **`TypedefKind::label()`** returns a human-readable string (`"struct"`, `"union"`, `"pointer"`, `"function pointer"`, etc.). Used by `display::format_typedef_summary` to render typedef-only hits like `HANDLE → PVOID → void *   (pointer)`.
 - **bb-funcs `enriched` module** owns the sparse metadata rendering. Enriched JSON is composed by starting from `p.to_json()` / `f.to_json()` and extending with sparse metadata. bb-clang stays generic.
 - **bb-funcs `where_filter` module** evaluates SQL WHERE clauses via `bb-sql::Evaluator`.
 - **`bb_cli::terminal_width()`** is the shared terminal width helper used by all CLIs.
@@ -126,13 +130,19 @@ Tests use `serial_test` because libclang is not fully thread-safe. Integration t
 | `function/abi.rs` | Calling conventions + ABI parameter assignment engine |
 | `function/param.rs` | Param type with `is_stack()`, `size()`, embeds `TypeInfo` |
 | `type_info.rs` | Shared `TypeInfo` struct: type classification (pointer, array, const, volatile, function pointer, underlying type) |
-| `typedef.rs` | `TypedefIndex` / `Typedef` / `TypedefKind`: translation-unit-scoped typedef resolution (alias name → canonical form + chain + kind) |
+| `typedef.rs` | `TypedefIndex` / `Typedef` / `TypedefKind` (+ `TypedefKind::label()` for display): translation-unit-scoped typedef resolution (alias name → canonical form + chain + kind) |
+| `record.rs` | `RecordKind` (Struct/Union) discriminator + `AnonRef { kind, enclosing_record, field_path }` cross-reference for anonymous nested records |
+| `struct_/mod.rs` | `Struct` type (rejects `UnionDecl`), `extract_nested_records` walker, `collect_nested_from_fields` |
+| `struct_/field.rs` | `Field` type. `build_anon_record_field` + `anon_record_offset_in_parent` synthesize Field entries for sibling anon-record decls. `Field::record_kind()` dispatches on the underlying type's kind. |
+| `union_/mod.rs` | `Union` type, parallel to `Struct` |
 | `constant/tokens.rs` | Clang ↔ cexpr token conversion |
 | `constant/macro_.rs` | Macro resolution with identifier substitution |
 | `ext.rs` | Extension traits for clang types (`UnderlyingType`, `AnonymousType`, etc.) |
-| `json.rs` | `ToJson` trait + impls for all entity types (Struct, Field, Enum, Constant, Function, Param) |
+| `json.rs` | `ToJson` trait + impls for all entity types (Struct, Union, Field, Enum, Constant, Function, Param). `records_to_json_full(structs, unions)` produces the mixed-kind `{ types, referenced_types }` envelope. |
 | `display/constant.rs` | Constant rendering |
 | `display/function.rs` | Function rendering (list, detail, shared formatters) |
+| `display/struct_.rs` | `render_struct` / `render_union` (mirrored), `typedef_annotation` for the dim `(canonical)` chip |
+| `display/typedef.rs` | `format_typedef_summary` — one-line typedef-only hit row |
 
 Files using trailing underscores (`struct_/`, `enum_/`, `macro_.rs`) follow the Rust convention for avoiding keyword conflicts.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -274,6 +274,7 @@ dependencies = [
  "bb-sql",
  "clang",
  "clap",
+ "colored",
  "serde",
  "serde_json",
  "serial_test",

--- a/cli/bb-funcs/src/enriched.rs
+++ b/cli/bb-funcs/src/enriched.rs
@@ -9,8 +9,10 @@ use std::collections::HashMap;
 use std::fmt::Write;
 
 use bb_arch::ToJson as AbiToJson;
-use bb_clang::display::{format_abi_param, format_return_location, format_tags};
-use bb_clang::{Constant, Function, Param, SourceLocation, ToJson};
+use bb_clang::display::{
+    format_abi_param, format_return_location, format_tags, typedef_annotation,
+};
+use bb_clang::{Constant, Function, Param, SourceLocation, ToJson, TypedefIndex};
 use bb_cli::terminal_width;
 use bb_consts_lib::{ConstFilter, collect_constants, collect_enums};
 use bb_sdk::SdkMode;
@@ -123,11 +125,15 @@ pub fn numeric_const_lookup(lookup: &ConstantLookup) -> HashMap<String, u64> {
 /* ─────────────────────── Full enriched detail view ─────────────────────── */
 
 /// Render the full enriched detail view for a function.
+///
+/// `typedef_index`, when supplied, annotates typedef'd parameter and
+/// return types with their canonical form in the ABI section.
 #[must_use]
 pub fn render_enriched_detail(
     f: &Function,
     mode: SdkMode,
     const_lookup: Option<&ConstantLookup>,
+    typedef_index: Option<&TypedefIndex>,
 ) -> String {
     let ef = EnrichedFunction::new_ref(f, mode);
     let entry = ef.entry;
@@ -135,7 +141,7 @@ pub fn render_enriched_detail(
 
     render_prototype(&mut out, f, entry);
     render_header_tags(&mut out, f, entry);
-    render_abi_section(&mut out, f);
+    render_abi_section(&mut out, f, typedef_index);
     if let Some(entry) = entry {
         render_arguments_section(&mut out, f, entry, const_lookup);
         render_info_section(&mut out, entry);
@@ -177,7 +183,7 @@ fn render_header_tags(out: &mut String, f: &Function, entry: Option<Entry<'_>>) 
 }
 
 /// ABI section: stack note, param rows, return location.
-fn render_abi_section(out: &mut String, f: &Function) {
+fn render_abi_section(out: &mut String, f: &Function, typedef_index: Option<&TypedefIndex>) {
     let _ = writeln!(out);
     let _ = writeln!(out, "  {}", "ABI".white().bold().underline());
 
@@ -197,13 +203,23 @@ fn render_abi_section(out: &mut String, f: &Function) {
         for (i, p) in params.iter().enumerate() {
             let is_last = i == params.len() - 1;
             let connector = if is_last { "╰─" } else { "├─" };
-            let _ = writeln!(out, "  {} {}", connector.dimmed(), format_abi_param(i, p));
+            let _ = writeln!(
+                out,
+                "  {} {}",
+                connector.dimmed(),
+                format_abi_param(i, p, typedef_index)
+            );
         }
     }
 
-    let ret_type = f.get_return_type_name().cyan();
+    let ret_raw = f.get_return_type_name();
+    let ret_styled_cyan = ret_raw.cyan();
     let ret_loc = format_return_location(f.get_return_location()).yellow();
-    let _ = writeln!(out, "  {} {ret_loc}  {ret_type}", "╰".dimmed());
+    let ret_cell = match typedef_annotation(ret_raw, None, typedef_index) {
+        Some(canon) => format!("{ret_styled_cyan} {}", format!("({canon})").dimmed()),
+        None => ret_styled_cyan.to_string(),
+    };
+    let _ = writeln!(out, "  {} {ret_loc}  {ret_cell}", "╰".dimmed());
 }
 
 /// Arguments section: per-param constant values in tables.

--- a/cli/bb-funcs/src/main.rs
+++ b/cli/bb-funcs/src/main.rs
@@ -2,6 +2,7 @@ use std::path::PathBuf;
 
 use anyhow::Result;
 use bb_clang::Function;
+use bb_clang::TypedefIndex;
 use bb_clang::display::render_function_list;
 use bb_cli::{current_command_string, get_header_config, print_suggestions};
 use bb_funcs_lib::enriched::{
@@ -224,6 +225,10 @@ fn main() -> Result<()> {
 
     let mode = args.shared.mode;
 
+    // Build the typedef index once so the detail renderer can annotate
+    // typedef'd parameter / return types (e.g. `HANDLE (void *)`).
+    let typedef_index = TypedefIndex::build(&tu);
+
     if let Some(ref path) = args.sqlite {
         let json_rows: Vec<Value> = funcs
             .iter()
@@ -233,7 +238,13 @@ fn main() -> Result<()> {
     } else if args.json {
         print_json(funcs.as_slice(), mode, const_lookup.as_ref())?;
     } else {
-        print_display(funcs.as_slice(), detail, mode, const_lookup.as_ref());
+        print_display(
+            funcs.as_slice(),
+            detail,
+            mode,
+            const_lookup.as_ref(),
+            Some(&typedef_index),
+        );
     }
 
     Ok(())
@@ -246,10 +257,14 @@ fn print_display(
     detail: bool,
     mode: bb_sdk::SdkMode,
     const_lookup: Option<&ConstantLookup>,
+    typedef_index: Option<&TypedefIndex>,
 ) {
     if detail {
         for (i, f) in funcs.iter().enumerate() {
-            print!("{}", render_enriched_detail(f, mode, const_lookup));
+            print!(
+                "{}",
+                render_enriched_detail(f, mode, const_lookup, typedef_index)
+            );
             if i < funcs.len() - 1 {
                 println!();
             }

--- a/cli/bb-types/Cargo.toml
+++ b/cli/bb-types/Cargo.toml
@@ -20,6 +20,7 @@ bb-sql.workspace = true
 clang.workspace = true
 clap.workspace = true
 anyhow.workspace = true
+colored.workspace = true
 serde_json.workspace = true
 serde.workspace = true
 

--- a/cli/bb-types/src/lib.rs
+++ b/cli/bb-types/src/lib.rs
@@ -5,9 +5,16 @@
 //! [the CLI](bb-types) and [the TUI](bb-types-tui), and also reduces
 //! the amount of code present in main.rs
 
-use bb_clang::{Struct, Typedef, TypedefIndex};
+use std::collections::HashSet;
+
+use bb_clang::display::format_typedef_summary;
+use bb_clang::json::records_to_json_full;
+use bb_clang::{Struct, ToJson, Typedef, TypedefIndex, Union};
+use bb_cli::print_suggestions;
 use bb_shared::glob_match;
 use clang::{Entity, EntityKind, TranslationUnit};
+use colored::Colorize;
+use serde_json::Value;
 
 /* ────────────────────── Parse, iter, collect, filter ────────────────────── */
 
@@ -47,17 +54,78 @@ pub fn collect_structs<'a>(
 
 /// Iterate over struct/class declarations in a [`TranslationUnit`].
 ///
-/// Typedefs are intentionally **not** included here — they're surfaced
-/// separately via [`TypedefIndex`]. A typedef-name search finds its
-/// canonical struct through that index, then is reported as a regular
-/// struct hit with its alias attached.
+/// Excludes [`EntityKind::UnionDecl`] — unions are surfaced through
+/// the parallel [`iter_unions`] and [`collect_unions`] entry points so
+/// the [`Struct`] / [`Union`] types stay strictly separated. Anonymous
+/// nested unions never appear as top-level decls in the TU, so the
+/// filter is exact.
 pub fn iter_structs<'a>(tu: &'a TranslationUnit<'a>) -> impl Iterator<Item = Entity<'a>> {
-    tu.get_entity().get_children().into_iter().filter(|e| {
-        matches!(
-            e.get_kind(),
-            EntityKind::StructDecl | EntityKind::ClassDecl | EntityKind::UnionDecl
-        )
-    })
+    tu.get_entity()
+        .get_children()
+        .into_iter()
+        .filter(|e| matches!(e.get_kind(), EntityKind::StructDecl | EntityKind::ClassDecl))
+}
+
+/// Iterate over union declarations in a [`TranslationUnit`].
+///
+/// Yields only **named** top-level unions (e.g. `_LARGE_INTEGER`).
+/// Anonymous unions never appear at the top level — they always live
+/// inside a parent record and are surfaced via that record's
+/// `referenced_unions` slot.
+pub fn iter_unions<'a>(tu: &'a TranslationUnit<'a>) -> impl Iterator<Item = Entity<'a>> {
+    tu.get_entity()
+        .get_children()
+        .into_iter()
+        .filter(|e| e.get_kind() == EntityKind::UnionDecl)
+}
+
+/// Collect every named union in the TU that matches `filter`.
+///
+/// Mirrors [`collect_structs`]: optional [`TypedefIndex`] attaches
+/// typedef aliases (so `_LARGE_INTEGER` carries `["LARGE_INTEGER"]`),
+/// and the filter's name pattern matches against both the canonical
+/// name and every alias.
+#[must_use]
+pub fn collect_unions<'a>(
+    tu: &'a TranslationUnit<'a>,
+    filter: &StructFilter,
+    index: Option<&TypedefIndex>,
+) -> Vec<Union<'a>> {
+    iter_unions(tu)
+        .filter(|e| filter.matches_header(e))
+        .filter_map(|e| Union::try_from(e).ok())
+        .map(|u| {
+            if let Some(idx) = index {
+                let aliases = idx.aliases_for(u.get_name()).to_vec();
+                u.with_aliases(aliases)
+            } else {
+                u
+            }
+        })
+        .filter(|u| filter.matches_union_name(u))
+        .collect()
+}
+
+/// Find a single named union by its exact canonical name.
+/// Mirrors [`find_struct_by_name`].
+#[must_use]
+pub fn find_union_by_name<'a>(
+    tu: &'a TranslationUnit<'a>,
+    name: &str,
+    index: Option<&TypedefIndex>,
+) -> Option<Union<'a>> {
+    iter_unions(tu)
+        .filter(|e| e.get_name().as_deref() == Some(name))
+        .filter_map(|e| Union::try_from(e).ok())
+        .map(|u| {
+            if let Some(idx) = index {
+                let aliases = idx.aliases_for(u.get_name()).to_vec();
+                u.with_aliases(aliases)
+            } else {
+                u
+            }
+        })
+        .next()
 }
 
 /// Find every typedef in `index` whose name matches `filter.name_pattern`.
@@ -122,8 +190,8 @@ impl StructFilter {
     /// Whether a fully-built [`Struct`] matches the name pattern.
     ///
     /// Matches against the struct's canonical name and every typedef
-    /// alias, so a search for `LARGE_INTEGER` resolves to the
-    /// `_LARGE_INTEGER` struct via its alias.
+    /// alias, so a search for `FILETIME` resolves to the
+    /// `_FILETIME` struct via its alias.
     #[must_use]
     pub fn matches_struct_name(&self, s: &Struct) -> bool {
         let Some(ref pattern) = self.name_pattern else {
@@ -133,6 +201,22 @@ impl StructFilter {
             return true;
         }
         s.get_aliases()
+            .iter()
+            .any(|a| glob_match(a, pattern, self.case_sensitive))
+    }
+
+    /// Whether a fully-built [`Union`] matches the name pattern.
+    /// Mirrors [`Self::matches_struct_name`] — `LARGE_INTEGER` resolves
+    /// to `_LARGE_INTEGER` via its typedef alias.
+    #[must_use]
+    pub fn matches_union_name(&self, u: &Union) -> bool {
+        let Some(ref pattern) = self.name_pattern else {
+            return true;
+        };
+        if glob_match(u.get_name(), pattern, self.case_sensitive) {
+            return true;
+        }
+        u.get_aliases()
             .iter()
             .any(|a| glob_match(a, pattern, self.case_sensitive))
     }
@@ -159,4 +243,264 @@ impl StructFilter {
     pub fn matches(&self, entity: &Entity) -> bool {
         self.matches_name(entity) && self.matches_header(entity)
     }
+}
+
+/* ──────────────────────────────── Results ───────────────────────────────── */
+
+/// One end-to-end result of running a `bb-types` query: every record
+/// the user's filter resolved (structs + unions) plus the typedef
+/// hits that surfaced alongside.
+///
+/// Built by [`collect_results`]. `typedef_hits` is the full set used
+/// for JSON / SQLite output; `typedef_hits_text` is the filtered
+/// view for plain-text display, with redundant stubs (those already
+/// covered by an `[aka …]` chip on a rendered record) suppressed.
+pub struct TypeResults<'tu, 'idx> {
+    pub structs: Vec<Struct<'tu>>,
+    pub unions: Vec<Union<'tu>>,
+    pub typedef_hits: Vec<&'idx Typedef>,
+    pub typedef_hits_text: Vec<&'idx Typedef>,
+}
+
+impl<'tu, 'idx> TypeResults<'tu, 'idx> {
+    /// `true` when nothing matched — caller should fall back to
+    /// [`suggest_alternatives`].
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.structs.is_empty() && self.unions.is_empty() && self.typedef_hits.is_empty()
+    }
+
+    /// Top-level JSON shape:
+    ///
+    /// ```jsonc
+    /// {
+    ///   "command":          "...",
+    ///   "types":            [ /* structs + unions, distinguished by kind */ ],
+    ///   "referenced_types": [ /* every record reachable through fields */ ],
+    ///   "typedefs":         [ /* all typedef hits */ ]
+    /// }
+    /// ```
+    ///
+    /// Delegates to [`bb_clang::json::records_to_json_full`] for the
+    /// `types` + `referenced_types` half, then wraps with the
+    /// CLI-level `command` and `typedefs` envelope.
+    #[must_use]
+    pub fn to_json_value(&self, command: String) -> Value {
+        let typedefs_value =
+            serde_json::to_value(&self.typedef_hits).expect("Typedef list serializes");
+        let mut output = records_to_json_full(&self.structs, &self.unions);
+        let obj = output
+            .as_object_mut()
+            .expect("records_to_json_full returns an object");
+        obj.insert("command".to_string(), Value::String(command));
+        obj.insert("typedefs".to_string(), typedefs_value);
+        output
+    }
+
+    /// Records (structs + unions, distinguished by `"kind"`)
+    /// flattened to one row per record, ready for
+    /// [`bb_sql::export_json_to_sqlite`] under the `"types"` table.
+    #[must_use]
+    pub fn records_as_json_rows(&self) -> Vec<Value> {
+        let mut rows: Vec<Value> = self.structs.iter().map(ToJson::to_json).collect();
+        rows.extend(self.unions.iter().map(ToJson::to_json));
+        rows
+    }
+
+    /// Typedef hits as JSON rows, ready for SQLite export under the
+    /// `"typedefs"` table.
+    pub fn typedefs_as_json_rows(&self) -> anyhow::Result<Vec<Value>> {
+        self.typedef_hits
+            .iter()
+            .map(|t| serde_json::to_value(t).map_err(anyhow::Error::from))
+            .collect()
+    }
+
+    /// `WinDbg` `dt`-style plain-text rendering. Renders every struct,
+    /// then every union, then a trailing typedefs section for hits not
+    /// already covered by an `[aka …]` chip on a rendered record.
+    #[must_use]
+    pub fn format_display(
+        &self,
+        depth: usize,
+        field_name: Option<&str>,
+        typedef_index: Option<&TypedefIndex>,
+    ) -> String {
+        let mut out = String::new();
+        for s in &self.structs {
+            out.push_str(&s.display(depth, field_name, typedef_index));
+        }
+        for u in &self.unions {
+            out.push_str(&u.display(depth, field_name, typedef_index));
+        }
+
+        if !self.typedef_hits_text.is_empty() {
+            if !self.structs.is_empty() || !self.unions.is_empty() {
+                out.push('\n');
+            }
+            out.push_str(&format!("{}\n", "typedefs".white().bold().underline()));
+            for t in &self.typedef_hits_text {
+                out.push_str(&format_typedef_summary(t));
+                out.push('\n');
+            }
+        }
+
+        out
+    }
+}
+
+/// Run the full collection + auto-expansion + typedef-hit resolution
+/// pipeline for one `bb-types` query.
+///
+/// Steps, in order:
+/// 1. Collect structs and unions matching `filter`, with typedef
+///    aliases attached.
+/// 2. Auto-expand pointer-typedef targets: when the user searches
+///    `LPSECURITY_ATTRIBUTES`, also pull in `_SECURITY_ATTRIBUTES`.
+///    Same for union-typed pointer typedefs.
+/// 3. Resolve typedef hits: typedefs whose name matches the pattern,
+///    plus typedef aliases of any rendered record (so JSON consumers
+///    always see both directions).
+/// 4. Compute the filtered `typedef_hits_text` view: hide stubs whose
+///    target is already rendered (the `[aka …]` chip covers it).
+#[must_use]
+pub fn collect_results<'tu, 'idx>(
+    tu: &'tu TranslationUnit<'tu>,
+    filter: &StructFilter,
+    typedef_index: &'idx TypedefIndex,
+) -> TypeResults<'tu, 'idx> {
+    let mut structs = collect_structs(tu, filter, Some(typedef_index));
+    let mut unions = collect_unions(tu, filter, Some(typedef_index));
+
+    auto_expand_pointer_typedef_targets(tu, typedef_index, filter, &mut structs, &mut unions);
+
+    let rendered_canonical_names: HashSet<&str> = structs
+        .iter()
+        .map(Struct::get_name)
+        .chain(unions.iter().map(Union::get_name))
+        .collect();
+
+    let typedef_hits = collect_typedef_hits(typedef_index, filter, &rendered_canonical_names);
+    let typedef_hits_text =
+        suppress_redundant_typedef_stubs(&typedef_hits, &rendered_canonical_names);
+
+    TypeResults {
+        structs,
+        unions,
+        typedef_hits,
+        typedef_hits_text,
+    }
+}
+
+/// When the user's pattern matched a pointer typedef like
+/// `LPSECURITY_ATTRIBUTES`, also pull in the record it points at
+/// (here `_SECURITY_ATTRIBUTES`) so the layout dump is meaningful.
+fn auto_expand_pointer_typedef_targets<'tu>(
+    tu: &'tu TranslationUnit<'tu>,
+    typedef_index: &TypedefIndex,
+    filter: &StructFilter,
+    structs: &mut Vec<Struct<'tu>>,
+    unions: &mut Vec<Union<'tu>>,
+) {
+    let initial_typedef_pattern_hits = find_typedef_hits(typedef_index, filter);
+    let already: HashSet<String> = structs
+        .iter()
+        .map(|s| s.get_name().to_string())
+        .chain(unions.iter().map(|u| u.get_name().to_string()))
+        .collect();
+
+    let mut to_pull: Vec<String> = Vec::new();
+    let mut seen_pull: HashSet<String> = HashSet::new();
+    for td in &initial_typedef_pattern_hits {
+        let candidate = td
+            .canonical_decl_name
+            .as_deref()
+            .or(td.properties.underlying_record.as_deref());
+        if let Some(record_name) = candidate
+            && !already.contains(record_name)
+            && seen_pull.insert(record_name.to_string())
+        {
+            to_pull.push(record_name.to_string());
+        }
+    }
+
+    // Records have distinct namespaces in C, so a name resolves to at
+    // most one of struct / union.
+    for record_name in to_pull {
+        if let Some(s) = find_struct_by_name(tu, &record_name, Some(typedef_index)) {
+            structs.push(s);
+        } else if let Some(u) = find_union_by_name(tu, &record_name, Some(typedef_index)) {
+            unions.push(u);
+        }
+    }
+}
+
+/// Resolve every typedef the user could reasonably want surfaced:
+/// pattern-name matches plus reverse aliases of every rendered record.
+/// Sorted by name; deduplicated.
+fn collect_typedef_hits<'idx>(
+    typedef_index: &'idx TypedefIndex,
+    filter: &StructFilter,
+    rendered_canonical_names: &HashSet<&str>,
+) -> Vec<&'idx Typedef> {
+    let mut seen: HashSet<&str> = HashSet::new();
+    let mut acc: Vec<&Typedef> = Vec::new();
+
+    for t in find_typedef_hits(typedef_index, filter) {
+        if seen.insert(t.name.as_str()) {
+            acc.push(t);
+        }
+    }
+
+    for name in rendered_canonical_names {
+        for alias_name in typedef_index.aliases_for(name) {
+            if let Some(t) = typedef_index.lookup(alias_name)
+                && seen.insert(t.name.as_str())
+            {
+                acc.push(t);
+            }
+        }
+    }
+
+    acc.sort_by(|a, b| a.name.cmp(&b.name));
+    acc
+}
+
+/// Filter typedef hits down to those worth printing in plain-text
+/// output: a typedef whose target is already rendered as a record
+/// shows up as the record's `[aka …]` chip, so an additional stub
+/// row is noise. JSON / SQLite always keep the full list.
+fn suppress_redundant_typedef_stubs<'idx>(
+    hits: &[&'idx Typedef],
+    rendered_canonical_names: &HashSet<&str>,
+) -> Vec<&'idx Typedef> {
+    hits.iter()
+        .copied()
+        .filter(|t| {
+            let direct = t.canonical_decl_name.as_deref();
+            let via_pointer = t.properties.underlying_record.as_deref();
+            !direct.is_some_and(|c| rendered_canonical_names.contains(c))
+                && !via_pointer.is_some_and(|c| rendered_canonical_names.contains(c))
+        })
+        .collect()
+}
+
+/// Print a "did-you-mean" suggestion list to stdout when a query
+/// produced no records and no typedef hits. Candidates: every
+/// struct name, every union name, every typedef name in the TU.
+pub fn suggest_alternatives(
+    tu: &TranslationUnit<'_>,
+    typedef_index: &TypedefIndex,
+    pattern: Option<&str>,
+) {
+    let struct_names: Vec<String> = iter_structs(tu).filter_map(|e| e.get_name()).collect();
+    let union_names: Vec<String> = iter_unions(tu).filter_map(|e| e.get_name()).collect();
+    let mut candidates: Vec<&str> = struct_names.iter().map(String::as_str).collect();
+    candidates.extend(union_names.iter().map(String::as_str));
+    candidates.extend(typedef_index.names());
+    print_suggestions(
+        "structs, unions or typedefs",
+        pattern,
+        candidates.into_iter(),
+    );
 }

--- a/cli/bb-types/src/lib.rs
+++ b/cli/bb-types/src/lib.rs
@@ -21,11 +21,11 @@ use serde_json::Value;
 /// Collect every struct/class in the TU that matches `filter`.
 ///
 /// If `index` is supplied, each returned [`Struct`] is annotated with its
-/// typedef aliases (e.g. `_LARGE_INTEGER` will carry `["LARGE_INTEGER"]`).
+/// typedef aliases (e.g. `_FILETIME` will carry `["FILETIME"]`).
 /// The filter's name pattern is then matched against the struct's
 /// canonical name **and** every alias, so users can search by either form
-/// — `bb-types -s LARGE_INTEGER` and `bb-types -s _LARGE_INTEGER` both
-/// hit the same struct.
+/// — `bb-types -s FILETIME` and `bb-types -s _FILETIME` both hit the
+/// same struct.
 ///
 /// When `index` is `None`, behaves exactly like the legacy pre-typedef
 /// code path: name-only matching on `Entity::get_name()`, no aliases.
@@ -53,12 +53,6 @@ pub fn collect_structs<'a>(
 }
 
 /// Iterate over struct/class declarations in a [`TranslationUnit`].
-///
-/// Excludes [`EntityKind::UnionDecl`] — unions are surfaced through
-/// the parallel [`iter_unions`] and [`collect_unions`] entry points so
-/// the [`Struct`] / [`Union`] types stay strictly separated. Anonymous
-/// nested unions never appear as top-level decls in the TU, so the
-/// filter is exact.
 pub fn iter_structs<'a>(tu: &'a TranslationUnit<'a>) -> impl Iterator<Item = Entity<'a>> {
     tu.get_entity()
         .get_children()

--- a/cli/bb-types/src/lib.rs
+++ b/cli/bb-types/src/lib.rs
@@ -5,26 +5,72 @@
 //! [the CLI](bb-types) and [the TUI](bb-types-tui), and also reduces
 //! the amount of code present in main.rs
 
-use bb_clang::Struct;
+use bb_clang::{Struct, Typedef, TypedefIndex};
 use bb_shared::glob_match;
 use clang::{Entity, EntityKind, TranslationUnit};
 
 /* ────────────────────── Parse, iter, collect, filter ────────────────────── */
 
+/// Collect every struct/class in the TU that matches `filter`.
+///
+/// If `index` is supplied, each returned [`Struct`] is annotated with its
+/// typedef aliases (e.g. `_LARGE_INTEGER` will carry `["LARGE_INTEGER"]`).
+/// The filter's name pattern is then matched against the struct's
+/// canonical name **and** every alias, so users can search by either form
+/// — `bb-types -s LARGE_INTEGER` and `bb-types -s _LARGE_INTEGER` both
+/// hit the same struct.
+///
+/// When `index` is `None`, behaves exactly like the legacy pre-typedef
+/// code path: name-only matching on `Entity::get_name()`, no aliases.
 #[must_use]
-pub fn collect_structs<'a>(tu: &'a TranslationUnit<'a>, filter: &StructFilter) -> Vec<Struct<'a>> {
+pub fn collect_structs<'a>(
+    tu: &'a TranslationUnit<'a>,
+    filter: &StructFilter,
+    index: Option<&TypedefIndex>,
+) -> Vec<Struct<'a>> {
     iter_structs(tu)
-        .filter(|e| filter.matches(e))
+        // Header filter still runs at entity level — cheap and avoids
+        // building a Struct for every entity in the TU.
+        .filter(|e| filter.matches_header(e))
         .filter_map(|e| Struct::try_from(e).ok())
+        .map(|s| {
+            if let Some(idx) = index {
+                let aliases = idx.aliases_for(s.get_name()).to_vec();
+                s.with_aliases(aliases)
+            } else {
+                s
+            }
+        })
+        .filter(|s| filter.matches_struct_name(s))
         .collect()
 }
 
-/// Iterate over struct declarations in a [`TranslationUnit`].
+/// Iterate over struct/class declarations in a [`TranslationUnit`].
+///
+/// Typedefs are intentionally **not** included here — they're surfaced
+/// separately via [`TypedefIndex`]. A typedef-name search finds its
+/// canonical struct through that index, then is reported as a regular
+/// struct hit with its alias attached.
 pub fn iter_structs<'a>(tu: &'a TranslationUnit<'a>) -> impl Iterator<Item = Entity<'a>> {
-    tu.get_entity()
-        .get_children()
-        .into_iter()
-        .filter(|e| matches!(e.get_kind(), EntityKind::StructDecl | EntityKind::ClassDecl))
+    tu.get_entity().get_children().into_iter().filter(|e| {
+        matches!(
+            e.get_kind(),
+            EntityKind::StructDecl | EntityKind::ClassDecl | EntityKind::UnionDecl
+        )
+    })
+}
+
+/// Find every typedef in `index` whose name matches `filter.name_pattern`.
+///
+/// Used by the CLI to surface typedef-only hits (`HANDLE`, `PVOID`, ...)
+/// when no struct matches the user's search. Returns an empty slice when
+/// the filter has no name pattern.
+#[must_use]
+pub fn find_typedef_hits<'i>(index: &'i TypedefIndex, filter: &StructFilter) -> Vec<&'i Typedef> {
+    let Some(ref pattern) = filter.name_pattern else {
+        return Vec::new();
+    };
+    index.match_pattern(pattern, filter.case_sensitive)
 }
 
 /* ────────────────────────────────── Match ───────────────────────────────── */
@@ -36,11 +82,38 @@ pub struct StructFilter {
 }
 
 impl StructFilter {
+    /// Whether `entity`'s source file matches the header filter (if any).
+    ///
+    /// Cheap entity-level prefilter that runs before [`Struct::try_from`].
     #[must_use]
-    pub fn matches(&self, entity: &Entity) -> bool {
-        self.matches_name(entity) && self.matches_header(entity)
+    pub fn matches_header(&self, entity: &Entity) -> bool {
+        self.header_filter
+            .as_ref()
+            .is_none_or(|f| bb_clang::entity_in_header(entity, f))
     }
 
+    /// Whether a fully-built [`Struct`] matches the name pattern.
+    ///
+    /// Matches against the struct's canonical name and every typedef
+    /// alias, so a search for `LARGE_INTEGER` resolves to the
+    /// `_LARGE_INTEGER` struct via its alias.
+    #[must_use]
+    pub fn matches_struct_name(&self, s: &Struct) -> bool {
+        let Some(ref pattern) = self.name_pattern else {
+            return true;
+        };
+        if glob_match(s.get_name(), pattern, self.case_sensitive) {
+            return true;
+        }
+        s.get_aliases()
+            .iter()
+            .any(|a| glob_match(a, pattern, self.case_sensitive))
+    }
+
+    /// Legacy entity-only name match.
+    ///
+    /// Retained for callers that don't have a built [`Struct`] yet (none
+    /// in tree as of now, but kept stable for future entity-level uses).
     #[must_use]
     pub fn matches_name(&self, entity: &Entity) -> bool {
         match (&self.name_pattern, entity.get_name()) {
@@ -50,10 +123,13 @@ impl StructFilter {
         }
     }
 
+    /// Entity-level prefilter combining name and header checks.
+    ///
+    /// Used by callers that filter on raw `Entity` (e.g. suggestion
+    /// lists). Note that `collect_structs` does the post-build name
+    /// match itself because aliases aren't known at entity time.
     #[must_use]
-    pub fn matches_header(&self, entity: &Entity) -> bool {
-        self.header_filter
-            .as_ref()
-            .is_none_or(|f| bb_clang::entity_in_header(entity, f))
+    pub fn matches(&self, entity: &Entity) -> bool {
+        self.matches_name(entity) && self.matches_header(entity)
     }
 }

--- a/cli/bb-types/src/lib.rs
+++ b/cli/bb-types/src/lib.rs
@@ -73,6 +73,33 @@ pub fn find_typedef_hits<'i>(index: &'i TypedefIndex, filter: &StructFilter) -> 
     index.match_pattern(pattern, filter.case_sensitive)
 }
 
+/// Find a single struct/union/class declaration by its exact canonical
+/// name. Used to auto-expand pointer-typedef targets — when a search
+/// surfaces `LPSECURITY_ATTRIBUTES`, we use this to also pull in the
+/// `_SECURITY_ATTRIBUTES` struct it points to.
+///
+/// Returns `None` if no declaration matches (e.g. the typedef points to
+/// an opaque struct never defined in the TU).
+#[must_use]
+pub fn find_struct_by_name<'a>(
+    tu: &'a TranslationUnit<'a>,
+    name: &str,
+    index: Option<&TypedefIndex>,
+) -> Option<Struct<'a>> {
+    iter_structs(tu)
+        .filter(|e| e.get_name().as_deref() == Some(name))
+        .filter_map(|e| Struct::try_from(e).ok())
+        .map(|s| {
+            if let Some(idx) = index {
+                let aliases = idx.aliases_for(s.get_name()).to_vec();
+                s.with_aliases(aliases)
+            } else {
+                s
+            }
+        })
+        .next()
+}
+
 /* ────────────────────────────────── Match ───────────────────────────────── */
 
 pub struct StructFilter {

--- a/cli/bb-types/src/main.rs
+++ b/cli/bb-types/src/main.rs
@@ -168,13 +168,27 @@ fn main() -> Result<()> {
     // inline below a struct render is redundant with the `[aka …]`
     // chip in the struct header. JSON / SQLite always include the full
     // typedef list, since machine consumers want both directions.
+    //
+    // Suppress when EITHER:
+    //  - `canonical_decl_name` names a rendered struct (direct alias
+    //    — `SECURITY_ATTRIBUTES` for `_SECURITY_ATTRIBUTES`).
+    //  - `underlying_record` names a rendered struct (pointer alias —
+    //    `LPSECURITY_ATTRIBUTES` whose canonical is `struct _… *` and
+    //    whose underlying_record is `_SECURITY_ATTRIBUTES`, which the
+    //    user is already seeing rendered above).
+    // Without the second check, pointer typedefs always survived the
+    // filter because their `canonical_decl_name` is always `None`.
     let typedef_hits_text: Vec<&Typedef> = typedef_hits
         .iter()
         .copied()
         .filter(|t| {
-            t.canonical_decl_name
-                .as_deref()
-                .is_none_or(|c| !rendered_canonical_names.contains(c))
+            let direct = t.canonical_decl_name.as_deref();
+            let via_pointer = t.properties.underlying_record.as_deref();
+            // Keep the typedef in text output unless one of its
+            // canonical-pointing fields names a struct we already
+            // rendered.
+            !direct.is_some_and(|c| rendered_canonical_names.contains(c))
+                && !via_pointer.is_some_and(|c| rendered_canonical_names.contains(c))
         })
         .collect();
 

--- a/cli/bb-types/src/main.rs
+++ b/cli/bb-types/src/main.rs
@@ -1,12 +1,13 @@
 use std::path::PathBuf;
 
 use anyhow::Result;
-use bb_clang::{Struct, ToJson};
+use bb_clang::{Struct, ToJson, Typedef, TypedefIndex};
 use bb_cli::{current_command_string, get_header_config, print_suggestions};
 use bb_sql::export_json_to_sqlite;
-use bb_types_lib::{StructFilter, collect_structs, iter_structs};
+use bb_types_lib::{StructFilter, collect_structs, find_typedef_hits, iter_structs};
 use clang::{Clang, Index};
 use clap::Parser;
+use colored::Colorize;
 use serde_json::Value;
 
 /* ─────────────────────────────────── CLI ────────────────────────────────── */
@@ -34,7 +35,8 @@ struct Args {
     #[arg(
         short = 's',
         long = "struct",
-        help = "Struct name pattern (supports * wildcard)"
+        help = "Struct name pattern (supports * wildcard). \
+                Matches typedef aliases too — `LARGE_INTEGER` finds `_LARGE_INTEGER`."
     )]
     struct_name: Option<String>,
 
@@ -73,30 +75,110 @@ fn main() -> Result<()> {
     // Parse headers.
     let tu = config.parse(&index, false)?;
 
+    // Build the typedef index once: needed to (1) discover aliases for
+    // every struct we render, (2) resolve typedef-only lookups like
+    // `HANDLE`, (3) drive the inline `(canonical)` annotation on field
+    // type cells.
+    let typedef_index = TypedefIndex::build(&tu);
+
     let filter = StructFilter {
         name_pattern: args.struct_name.clone(),
         header_filter: args.filter.clone(),
         case_sensitive: args.case_sensitive,
     };
-    let structs = collect_structs(&tu, &filter);
+    let structs = collect_structs(&tu, &filter, Some(&typedef_index));
 
-    // If no struct that matches our filter was found, try to print a suggestion.
-    if structs.is_empty() {
-        let names: Vec<String> = iter_structs(&tu).filter_map(|e| e.get_name()).collect();
+    // Resolve every typedef the user could reasonably want surfaced:
+    //
+    //  1. Typedefs whose **name** matches the search pattern. Surfaces
+    //     pointer/primitive typedefs that don't resolve to a struct
+    //     (e.g. `HANDLE`, `PVOID`) so they're never invisible.
+    //
+    //  2. Typedefs that resolve to any **rendered struct's canonical
+    //     name**. Surfaces struct aliases regardless of which name the
+    //     user typed — `-s LARGE_INTEGER` and `-s _LARGE_INTEGER` both
+    //     produce a `LARGE_INTEGER` typedef entry, so API consumers
+    //     always see the bidirectional mapping in one place.
+    //
+    // Results are merged + deduplicated by typedef name.
+    let rendered_canonical_names: std::collections::HashSet<&str> =
+        structs.iter().map(Struct::get_name).collect();
+    let typedef_hits: Vec<&Typedef> = {
+        let mut seen: std::collections::HashSet<&str> = std::collections::HashSet::new();
+        let mut acc: Vec<&Typedef> = Vec::new();
+
+        // Pattern matches.
+        for t in find_typedef_hits(&typedef_index, &filter) {
+            if seen.insert(t.name.as_str()) {
+                acc.push(t);
+            }
+        }
+
+        // Aliases of every rendered struct.
+        for s in &structs {
+            for alias_name in typedef_index.aliases_for(s.get_name()) {
+                if let Some(t) = typedef_index.lookup(alias_name)
+                    && seen.insert(t.name.as_str())
+                {
+                    acc.push(t);
+                }
+            }
+        }
+
+        acc.sort_by(|a, b| a.name.cmp(&b.name));
+        acc
+    };
+
+    // Suppress noise in plain-text rendering: a typedef stub printed
+    // inline below a struct render is redundant with the `[aka …]`
+    // chip in the struct header. JSON / SQLite always include the full
+    // typedef list, since machine consumers want both directions.
+    let typedef_hits_text: Vec<&Typedef> = typedef_hits
+        .iter()
+        .copied()
+        .filter(|t| {
+            t.canonical_decl_name
+                .as_deref()
+                .is_none_or(|c| !rendered_canonical_names.contains(c))
+        })
+        .collect();
+
+    // No-results suggestion: include both struct names and typedef names
+    // in the candidate pool. The user might be off by an underscore or a
+    // capitalization.
+    if structs.is_empty() && typedef_hits.is_empty() {
+        let struct_names: Vec<String> =
+            iter_structs(&tu).filter_map(|e| e.get_name()).collect();
+        let mut candidates: Vec<&str> = struct_names.iter().map(String::as_str).collect();
+        candidates.extend(typedef_index.names());
         print_suggestions(
-            "structs",
+            "structs or typedefs",
             args.struct_name.as_deref(),
-            names.iter().map(String::as_str),
+            candidates.into_iter(),
         );
     }
 
     if let Some(ref path) = args.sqlite {
         let json_rows: Vec<Value> = structs.iter().map(bb_clang::ToJson::to_json).collect();
         export_json_to_sqlite(path, "types", &json_rows)?;
+        // Export typedef hits to a sibling table for symmetry. Always
+        // create the table so consumers can rely on the schema; an empty
+        // typedef set produces an empty table.
+        let typedef_rows: Vec<Value> = typedef_hits
+            .iter()
+            .map(|t| serde_json::to_value(t).expect("Typedef serializes"))
+            .collect();
+        export_json_to_sqlite(path, "typedefs", &typedef_rows)?;
     } else if args.json {
-        print_json(structs.as_slice())?;
+        print_json(structs.as_slice(), &typedef_hits)?;
     } else {
-        print_display(structs.as_slice(), args.depth, &args.field_name);
+        print_display(
+            structs.as_slice(),
+            args.depth,
+            &args.field_name,
+            Some(&typedef_index),
+            &typedef_hits_text,
+        );
     }
 
     Ok(())
@@ -106,28 +188,110 @@ fn main() -> Result<()> {
 
 /// Print using `WinDbg` `dt`, tree-like structure style.
 ///
-/// # Arguments
-///
-/// * `structs` - The [`Struct`] entities to display.
-/// * `depth` - The depth of type expansion to be shown inline.
-/// * `field_name` - Particular field to filter for in [`Struct`].
-fn print_display(structs: &[Struct], depth: usize, field_name: &Option<String>) {
+/// Renders each struct (with typedef aliases in its header and dim
+/// `(canonical)` annotations on typedef'd field types), then renders any
+/// typedef-only hits (`HANDLE → PVOID → void *`) as a separate trailing
+/// section.
+fn print_display(
+    structs: &[Struct],
+    depth: usize,
+    field_name: &Option<String>,
+    typedef_index: Option<&TypedefIndex>,
+    typedef_hits: &[&Typedef],
+) {
     for s in structs {
-        print!("{}", s.display(depth, field_name.as_deref()));
+        print!("{}", s.display(depth, field_name.as_deref(), typedef_index));
+    }
+
+    if !typedef_hits.is_empty() {
+        if !structs.is_empty() {
+            println!();
+        }
+        println!("{}", "typedefs".white().bold().underline());
+        for t in typedef_hits {
+            print_typedef_summary(t);
+        }
     }
 }
 
-/// Print JSON with `types` and `referenced_types` arrays.
+/// One-line summary for a typedef-only hit.
 ///
-/// Uses [`ToJson::to_json_full`] on the struct slice to produce all matched
-/// types and their nested referenced types, fully expanded and deduplicated.
-fn print_json(structs: &[Struct]) -> anyhow::Result<()> {
+/// Example: `HANDLE  →  PVOID → void *   (pointer)  winnt.h:1234:5`.
+fn print_typedef_summary(t: &Typedef) {
+    let name = t.name.cyan().bold();
+    let arrow_chain: String = t
+        .chain
+        .iter()
+        .map(String::as_str)
+        .collect::<Vec<_>>()
+        .join(" → ");
+    let kind = format!("({})", typedef_kind_label(t.kind)).dimmed();
+    let loc = t
+        .location
+        .as_ref()
+        .map(|l| format!("  {}", l.to_string().dimmed()))
+        .unwrap_or_default();
+    println!("  {name}  →  {arrow_chain}   {kind}{loc}");
+}
+
+/// Human label for a [`bb_clang::TypedefKind`] in CLI output.
+const fn typedef_kind_label(k: bb_clang::TypedefKind) -> &'static str {
+    match k {
+        bb_clang::TypedefKind::Struct => "struct",
+        bb_clang::TypedefKind::Union => "union",
+        bb_clang::TypedefKind::Enum => "enum",
+        bb_clang::TypedefKind::FunctionPointer => "function pointer",
+        bb_clang::TypedefKind::Pointer => "pointer",
+        bb_clang::TypedefKind::Array => "array",
+        bb_clang::TypedefKind::Primitive => "primitive",
+        bb_clang::TypedefKind::Other => "other",
+    }
+}
+
+/// Print JSON with `types` and `typedefs` arrays, both always present.
+///
+/// Shape (designed for API consumers — predictable, no required indirection):
+///
+/// ```json
+/// {
+///   "command": "...",
+///   "types":    [ /* full Struct objects, each with `aliases` */ ],
+///   "typedefs": [
+///     {
+///       "name": "LARGE_INTEGER",
+///       "kind": "struct",
+///       "typedef_of": "_LARGE_INTEGER",
+///       "canonical": "_LARGE_INTEGER",
+///       "canonical_decl_name": "_LARGE_INTEGER",
+///       "chain": ["_LARGE_INTEGER"]
+///     },
+///     {
+///       "name": "HANDLE",
+///       "kind": "pointer",
+///       "typedef_of": "PVOID",
+///       "canonical": "void *",
+///       "chain": ["PVOID", "void *"]
+///     }
+///   ]
+/// }
+/// ```
+///
+/// - `types` is the full struct render (`ToJson::to_json_full`).
+/// - `typedefs` contains stubs for every typedef the user *searched* by
+///   name, including those that resolve to a struct already in `types`
+///   — so consumers can always look up by either name and find a clear
+///   pointer back to the canonical entry.
+fn print_json(structs: &[Struct], typedef_hits: &[&Typedef]) -> anyhow::Result<()> {
     let command = current_command_string();
+    let typedefs_value = serde_json::to_value(typedef_hits)?;
+
     let mut output = structs.to_json_full();
-    output
+    let obj = output
         .as_object_mut()
-        .unwrap()
-        .insert("command".to_string(), Value::String(command));
+        .expect("Struct slice to_json_full returns an object");
+    obj.insert("command".to_string(), Value::String(command));
+    obj.insert("typedefs".to_string(), typedefs_value);
+
     println!("{}", serde_json::to_string_pretty(&output)?);
     Ok(())
 }

--- a/cli/bb-types/src/main.rs
+++ b/cli/bb-types/src/main.rs
@@ -1,16 +1,12 @@
 use std::path::PathBuf;
 
 use anyhow::Result;
-use bb_clang::{Struct, ToJson, Typedef, TypedefIndex};
-use bb_cli::{current_command_string, get_header_config, print_suggestions};
+use bb_clang::TypedefIndex;
+use bb_cli::{current_command_string, get_header_config};
 use bb_sql::export_json_to_sqlite;
-use bb_types_lib::{
-    StructFilter, collect_structs, find_struct_by_name, find_typedef_hits, iter_structs,
-};
+use bb_types_lib::{StructFilter, TypeResults, collect_results, suggest_alternatives};
 use clang::{Clang, Index};
 use clap::Parser;
-use colored::Colorize;
-use serde_json::Value;
 
 /* ─────────────────────────────────── CLI ────────────────────────────────── */
 
@@ -24,7 +20,6 @@ struct Args {
     #[command(flatten)]
     shared: bb_cli::SharedArgs,
 
-    // Common options
     #[arg(long, help = "Output as JSON")]
     json: bool,
     #[arg(
@@ -37,8 +32,9 @@ struct Args {
     #[arg(
         short = 's',
         long = "struct",
-        help = "Struct name pattern (supports * wildcard). \
-                Matches typedef aliases too — `LARGE_INTEGER` finds `_LARGE_INTEGER`."
+        help = "Struct or union name pattern (supports * wildcard). \
+                Matches typedef aliases too — `LARGE_INTEGER` finds the union `_LARGE_INTEGER`, \
+                `OVERLAPPED` finds the struct `_OVERLAPPED`."
     )]
     struct_name: Option<String>,
 
@@ -64,23 +60,15 @@ struct Args {
     sqlite: Option<PathBuf>,
 }
 
+/* ────────────────────────────────── main ────────────────────────────────── */
+
 fn main() -> Result<()> {
     let args = Args::parse();
 
-    // Build header configuration.
     let config = get_header_config(&args.shared)?;
-
-    // Set up Clang.
     let clang_instance = Clang::new().expect("failed to initialize clang");
     let index = Index::new(&clang_instance, false, args.shared.diagnostics);
-
-    // Parse headers.
     let tu = config.parse(&index, false)?;
-
-    // Build the typedef index once: needed to (1) discover aliases for
-    // every struct we render, (2) resolve typedef-only lookups like
-    // `HANDLE`, (3) drive the inline `(canonical)` annotation on field
-    // type cells.
     let typedef_index = TypedefIndex::build(&tu);
 
     let filter = StructFilter {
@@ -88,257 +76,48 @@ fn main() -> Result<()> {
         header_filter: args.filter.clone(),
         case_sensitive: args.case_sensitive,
     };
-    let mut structs = collect_structs(&tu, &filter, Some(&typedef_index));
+    let results = collect_results(&tu, &filter, &typedef_index);
 
-    // Auto-expand pointer-typedef targets: when the user searches a
-    // pointer typedef like `LPSECURITY_ATTRIBUTES`, also pull in the
-    // `_SECURITY_ATTRIBUTES` struct it points to. Saves consumers from
-    // having to do a second lookup, and makes text rendering useful
-    // ("show me the layout of what this points at").
-    {
-        let initial_typedef_pattern_hits = find_typedef_hits(&typedef_index, &filter);
-        let already: std::collections::HashSet<String> =
-            structs.iter().map(|s| s.get_name().to_string()).collect();
-        let mut to_pull: Vec<String> = Vec::new();
-        let mut seen_pull: std::collections::HashSet<String> = std::collections::HashSet::new();
-        for td in &initial_typedef_pattern_hits {
-            // Prefer canonical_decl_name (direct record alias) over
-            // properties.underlying_record (pointer-to-record), but
-            // expand for either.
-            let candidate = td
-                .canonical_decl_name
-                .as_deref()
-                .or(td.properties.underlying_record.as_deref());
-            if let Some(record_name) = candidate
-                && !already.contains(record_name)
-                && seen_pull.insert(record_name.to_string())
-            {
-                to_pull.push(record_name.to_string());
-            }
-        }
-        for record_name in to_pull {
-            if let Some(s) = find_struct_by_name(&tu, &record_name, Some(&typedef_index)) {
-                structs.push(s);
-            }
-        }
-    }
-
-    // Resolve every typedef the user could reasonably want surfaced:
-    //
-    //  1. Typedefs whose **name** matches the search pattern. Surfaces
-    //     pointer/primitive typedefs that don't resolve to a struct
-    //     (e.g. `HANDLE`, `PVOID`) so they're never invisible.
-    //
-    //  2. Typedefs that resolve to any **rendered struct's canonical
-    //     name**. Surfaces struct aliases regardless of which name the
-    //     user typed — `-s LARGE_INTEGER` and `-s _LARGE_INTEGER` both
-    //     produce a `LARGE_INTEGER` typedef entry, so API consumers
-    //     always see the bidirectional mapping in one place.
-    //
-    // Results are merged + deduplicated by typedef name.
-    let rendered_canonical_names: std::collections::HashSet<&str> =
-        structs.iter().map(Struct::get_name).collect();
-    let typedef_hits: Vec<&Typedef> = {
-        let mut seen: std::collections::HashSet<&str> = std::collections::HashSet::new();
-        let mut acc: Vec<&Typedef> = Vec::new();
-
-        // Pattern matches.
-        for t in find_typedef_hits(&typedef_index, &filter) {
-            if seen.insert(t.name.as_str()) {
-                acc.push(t);
-            }
-        }
-
-        // Aliases of every rendered struct.
-        for s in &structs {
-            for alias_name in typedef_index.aliases_for(s.get_name()) {
-                if let Some(t) = typedef_index.lookup(alias_name)
-                    && seen.insert(t.name.as_str())
-                {
-                    acc.push(t);
-                }
-            }
-        }
-
-        acc.sort_by(|a, b| a.name.cmp(&b.name));
-        acc
-    };
-
-    // Suppress noise in plain-text rendering: a typedef stub printed
-    // inline below a struct render is redundant with the `[aka …]`
-    // chip in the struct header. JSON / SQLite always include the full
-    // typedef list, since machine consumers want both directions.
-    //
-    // Suppress when EITHER:
-    //  - `canonical_decl_name` names a rendered struct (direct alias
-    //    — `SECURITY_ATTRIBUTES` for `_SECURITY_ATTRIBUTES`).
-    //  - `underlying_record` names a rendered struct (pointer alias —
-    //    `LPSECURITY_ATTRIBUTES` whose canonical is `struct _… *` and
-    //    whose underlying_record is `_SECURITY_ATTRIBUTES`, which the
-    //    user is already seeing rendered above).
-    // Without the second check, pointer typedefs always survived the
-    // filter because their `canonical_decl_name` is always `None`.
-    let typedef_hits_text: Vec<&Typedef> = typedef_hits
-        .iter()
-        .copied()
-        .filter(|t| {
-            let direct = t.canonical_decl_name.as_deref();
-            let via_pointer = t.properties.underlying_record.as_deref();
-            // Keep the typedef in text output unless one of its
-            // canonical-pointing fields names a struct we already
-            // rendered.
-            !direct.is_some_and(|c| rendered_canonical_names.contains(c))
-                && !via_pointer.is_some_and(|c| rendered_canonical_names.contains(c))
-        })
-        .collect();
-
-    // No-results suggestion: include both struct names and typedef names
-    // in the candidate pool. The user might be off by an underscore or a
-    // capitalization.
-    if structs.is_empty() && typedef_hits.is_empty() {
-        let struct_names: Vec<String> =
-            iter_structs(&tu).filter_map(|e| e.get_name()).collect();
-        let mut candidates: Vec<&str> = struct_names.iter().map(String::as_str).collect();
-        candidates.extend(typedef_index.names());
-        print_suggestions(
-            "structs or typedefs",
-            args.struct_name.as_deref(),
-            candidates.into_iter(),
-        );
+    if results.is_empty() {
+        suggest_alternatives(&tu, &typedef_index, args.struct_name.as_deref());
     }
 
     if let Some(ref path) = args.sqlite {
-        let json_rows: Vec<Value> = structs.iter().map(bb_clang::ToJson::to_json).collect();
-        export_json_to_sqlite(path, "types", &json_rows)?;
-        // Export typedef hits to a sibling table for symmetry. Always
-        // create the table so consumers can rely on the schema; an empty
-        // typedef set produces an empty table.
-        let typedef_rows: Vec<Value> = typedef_hits
-            .iter()
-            .map(|t| serde_json::to_value(t).expect("Typedef serializes"))
-            .collect();
-        export_json_to_sqlite(path, "typedefs", &typedef_rows)?;
+        export_json_to_sqlite(path, "types", &results.records_as_json_rows())?;
+        export_json_to_sqlite(path, "typedefs", &results.typedefs_as_json_rows()?)?;
     } else if args.json {
-        print_json(structs.as_slice(), &typedef_hits)?;
+        print_json(&results)?;
     } else {
         print_display(
-            structs.as_slice(),
+            &results,
             args.depth,
-            &args.field_name,
-            Some(&typedef_index),
-            &typedef_hits_text,
+            args.field_name.as_deref(),
+            &typedef_index,
         );
     }
 
     Ok(())
 }
 
-/* ──────────────────────────────── Printing ──────────────────────────────── */
+/* ───────────────────────────────── Printing ─────────────────────────────── */
 
-/// Print using `WinDbg` `dt`, tree-like structure style.
-///
-/// Renders each struct (with typedef aliases in its header and dim
-/// `(canonical)` annotations on typedef'd field types), then renders any
-/// typedef-only hits (`HANDLE → PVOID → void *`) as a separate trailing
-/// section.
+/// Plain-text render of every struct + union + typedef hit, in
+/// `WinDbg` `dt` tree style.
 fn print_display(
-    structs: &[Struct],
+    results: &TypeResults,
     depth: usize,
-    field_name: &Option<String>,
-    typedef_index: Option<&TypedefIndex>,
-    typedef_hits: &[&Typedef],
+    field_name: Option<&str>,
+    typedef_index: &TypedefIndex,
 ) {
-    for s in structs {
-        print!("{}", s.display(depth, field_name.as_deref(), typedef_index));
-    }
-
-    if !typedef_hits.is_empty() {
-        if !structs.is_empty() {
-            println!();
-        }
-        println!("{}", "typedefs".white().bold().underline());
-        for t in typedef_hits {
-            print_typedef_summary(t);
-        }
-    }
+    print!(
+        "{}",
+        results.format_display(depth, field_name, Some(typedef_index))
+    );
 }
 
-/// One-line summary for a typedef-only hit.
-///
-/// Example: `HANDLE  →  PVOID → void *   (pointer)  winnt.h:1234:5`.
-fn print_typedef_summary(t: &Typedef) {
-    let name = t.name.cyan().bold();
-    let arrow_chain: String = t
-        .chain
-        .iter()
-        .map(String::as_str)
-        .collect::<Vec<_>>()
-        .join(" → ");
-    let kind = format!("({})", typedef_kind_label(t.kind)).dimmed();
-    let loc = t
-        .location
-        .as_ref()
-        .map(|l| format!("  {}", l.to_string().dimmed()))
-        .unwrap_or_default();
-    println!("  {name}  →  {arrow_chain}   {kind}{loc}");
-}
-
-/// Human label for a [`bb_clang::TypedefKind`] in CLI output.
-const fn typedef_kind_label(k: bb_clang::TypedefKind) -> &'static str {
-    match k {
-        bb_clang::TypedefKind::Struct => "struct",
-        bb_clang::TypedefKind::Union => "union",
-        bb_clang::TypedefKind::Enum => "enum",
-        bb_clang::TypedefKind::FunctionPointer => "function pointer",
-        bb_clang::TypedefKind::Pointer => "pointer",
-        bb_clang::TypedefKind::Array => "array",
-        bb_clang::TypedefKind::Primitive => "primitive",
-        bb_clang::TypedefKind::Other => "other",
-    }
-}
-
-/// Print JSON with `types` and `typedefs` arrays, both always present.
-///
-/// Shape (designed for API consumers — predictable, no required indirection):
-///
-/// ```json
-/// {
-///   "command": "...",
-///   "types":    [ /* full Struct objects, each with `aliases` */ ],
-///   "typedefs": [
-///     {
-///       "name": "LARGE_INTEGER",
-///       "kind": "struct",
-///       "canonical": "_LARGE_INTEGER",
-///       "canonical_decl_name": "_LARGE_INTEGER",
-///       "chain": ["_LARGE_INTEGER"]
-///     },
-///     {
-///       "name": "HANDLE",
-///       "kind": "pointer",
-///       "canonical": "void *",
-///       "chain": ["void *"]
-///     }
-///   ]
-/// }
-/// ```
-///
-/// - `types` is the full struct render (`ToJson::to_json_full`).
-/// - `typedefs` contains stubs for every typedef the user *searched* by
-///   name, including those that resolve to a struct already in `types`
-///   — so consumers can always look up by either name and find a clear
-///   pointer back to the canonical entry.
-fn print_json(structs: &[Struct], typedef_hits: &[&Typedef]) -> anyhow::Result<()> {
-    let command = current_command_string();
-    let typedefs_value = serde_json::to_value(typedef_hits)?;
-
-    let mut output = structs.to_json_full();
-    let obj = output
-        .as_object_mut()
-        .expect("Struct slice to_json_full returns an object");
-    obj.insert("command".to_string(), Value::String(command));
-    obj.insert("typedefs".to_string(), typedefs_value);
-
+/// Pretty-printed JSON dump of the full query result.
+fn print_json(results: &TypeResults) -> Result<()> {
+    let output = results.to_json_value(current_command_string());
     println!("{}", serde_json::to_string_pretty(&output)?);
     Ok(())
 }

--- a/cli/bb-types/src/main.rs
+++ b/cli/bb-types/src/main.rs
@@ -295,7 +295,6 @@ const fn typedef_kind_label(k: bb_clang::TypedefKind) -> &'static str {
 ///     {
 ///       "name": "LARGE_INTEGER",
 ///       "kind": "struct",
-///       "typedef_of": "_LARGE_INTEGER",
 ///       "canonical": "_LARGE_INTEGER",
 ///       "canonical_decl_name": "_LARGE_INTEGER",
 ///       "chain": ["_LARGE_INTEGER"]
@@ -303,9 +302,8 @@ const fn typedef_kind_label(k: bb_clang::TypedefKind) -> &'static str {
 ///     {
 ///       "name": "HANDLE",
 ///       "kind": "pointer",
-///       "typedef_of": "PVOID",
 ///       "canonical": "void *",
-///       "chain": ["PVOID", "void *"]
+///       "chain": ["void *"]
 ///     }
 ///   ]
 /// }

--- a/cli/bb-types/src/main.rs
+++ b/cli/bb-types/src/main.rs
@@ -4,7 +4,9 @@ use anyhow::Result;
 use bb_clang::{Struct, ToJson, Typedef, TypedefIndex};
 use bb_cli::{current_command_string, get_header_config, print_suggestions};
 use bb_sql::export_json_to_sqlite;
-use bb_types_lib::{StructFilter, collect_structs, find_typedef_hits, iter_structs};
+use bb_types_lib::{
+    StructFilter, collect_structs, find_struct_by_name, find_typedef_hits, iter_structs,
+};
 use clang::{Clang, Index};
 use clap::Parser;
 use colored::Colorize;
@@ -86,7 +88,40 @@ fn main() -> Result<()> {
         header_filter: args.filter.clone(),
         case_sensitive: args.case_sensitive,
     };
-    let structs = collect_structs(&tu, &filter, Some(&typedef_index));
+    let mut structs = collect_structs(&tu, &filter, Some(&typedef_index));
+
+    // Auto-expand pointer-typedef targets: when the user searches a
+    // pointer typedef like `LPSECURITY_ATTRIBUTES`, also pull in the
+    // `_SECURITY_ATTRIBUTES` struct it points to. Saves consumers from
+    // having to do a second lookup, and makes text rendering useful
+    // ("show me the layout of what this points at").
+    {
+        let initial_typedef_pattern_hits = find_typedef_hits(&typedef_index, &filter);
+        let already: std::collections::HashSet<String> =
+            structs.iter().map(|s| s.get_name().to_string()).collect();
+        let mut to_pull: Vec<String> = Vec::new();
+        let mut seen_pull: std::collections::HashSet<String> = std::collections::HashSet::new();
+        for td in &initial_typedef_pattern_hits {
+            // Prefer canonical_decl_name (direct record alias) over
+            // properties.underlying_record (pointer-to-record), but
+            // expand for either.
+            let candidate = td
+                .canonical_decl_name
+                .as_deref()
+                .or(td.properties.underlying_record.as_deref());
+            if let Some(record_name) = candidate
+                && !already.contains(record_name)
+                && seen_pull.insert(record_name.to_string())
+            {
+                to_pull.push(record_name.to_string());
+            }
+        }
+        for record_name in to_pull {
+            if let Some(s) = find_struct_by_name(&tu, &record_name, Some(&typedef_index)) {
+                structs.push(s);
+            }
+        }
+    }
 
     // Resolve every typedef the user could reasonably want surfaced:
     //

--- a/crates/bb-clang/src/display/enum_.rs
+++ b/crates/bb-clang/src/display/enum_.rs
@@ -31,6 +31,7 @@ pub fn render_enum_constants(
         e.get_name(),
         e.is_anonymous(),
         e.get_type_name(),
+        &[],
         e.get_location(),
     );
 

--- a/crates/bb-clang/src/display/function.rs
+++ b/crates/bb-clang/src/display/function.rs
@@ -119,7 +119,7 @@ pub fn format_abi_param(i: usize, p: &Param, typedef_index: Option<&TypedefIndex
     let loc_str = format_location(p.get_abi_location()).yellow();
     let raw_type = p.get_type_name();
     let type_styled = raw_type.cyan();
-    let underlying = p.get_type_info().underlying_type.as_deref();
+    let underlying = p.get_type_info().underlying_record.as_deref();
     let type_cell = match typedef_annotation(raw_type, underlying, typedef_index) {
         Some(canon) => format!("{type_styled} {}", format!("({canon})").dimmed()),
         None => type_styled.to_string(),

--- a/crates/bb-clang/src/display/function.rs
+++ b/crates/bb-clang/src/display/function.rs
@@ -11,6 +11,9 @@ use bb_arch::location::{MemoryOperand, ParamLocation, ReturnLocation};
 use colored::Colorize;
 
 use crate::function::{CallConv, Function, Param};
+use crate::typedef::TypedefIndex;
+
+use super::typedef_annotation;
 
 /* ────────────────────────── Operand formatting ─────────────────────────── */
 
@@ -100,9 +103,11 @@ fn format_param_sig(p: &Param) -> String {
 
 /// Format a single ABI parameter row: index, kind, location, size, type, name.
 ///
-/// Shared between `render_function_detail` and enriched rendering.
+/// Shared between `render_function_detail` and enriched rendering. When
+/// `typedef_index` is supplied, the type column is annotated with the
+/// canonical form for any typedef (e.g. `HANDLE (void *)`).
 #[must_use]
-pub fn format_abi_param(i: usize, p: &Param) -> String {
+pub fn format_abi_param(i: usize, p: &Param, typedef_index: Option<&TypedefIndex>) -> String {
     let kind = match p.get_abi_location() {
         ParamLocation::Direct { locations, .. } => match locations.first() {
             Some(MemoryOperand::Reg(_)) => "reg",
@@ -112,7 +117,13 @@ pub fn format_abi_param(i: usize, p: &Param) -> String {
         ParamLocation::Indirect { .. } => "indirect",
     };
     let loc_str = format_location(p.get_abi_location()).yellow();
-    let type_name = p.get_type_name().cyan();
+    let raw_type = p.get_type_name();
+    let type_styled = raw_type.cyan();
+    let underlying = p.get_type_info().underlying_type.as_deref();
+    let type_cell = match typedef_annotation(raw_type, underlying, typedef_index) {
+        Some(canon) => format!("{type_styled} {}", format!("({canon})").dimmed()),
+        None => type_styled.to_string(),
+    };
     let param_name = p.get_name().map_or_else(
         || "<unnamed>".dimmed().to_string(),
         |n| n.white().bold().to_string(),
@@ -123,7 +134,7 @@ pub fn format_abi_param(i: usize, p: &Param) -> String {
     let size_str = format!("[{size}]").green();
 
     let idx = i + 1;
-    format!("{idx}\t{kind:<8} {loc_str:<14} {size_str}  {type_name}  {param_name}")
+    format!("{idx}\t{kind:<8} {loc_str:<14} {size_str}  {type_cell}  {param_name}")
 }
 
 /// Render a single function as a tree list item with a connector.
@@ -180,9 +191,11 @@ pub fn render_function_list(funcs: &[Function]) -> String {
 /// Render a detailed ABI breakdown for a function.
 ///
 /// Shows the C signature as the tree root, with architecture/tags,
-/// parameter ABI locations, and return value placement as children.
+/// parameter ABI locations, and return value placement as children. When
+/// `typedef_index` is supplied, each parameter type and the return type
+/// gain a dim `(canonical)` annotation for typedef'd types.
 #[must_use]
-pub fn render_function_detail(f: &Function) -> String {
+pub fn render_function_detail(f: &Function, typedef_index: Option<&TypedefIndex>) -> String {
     let mut out = String::new();
 
     // Header: C signature as the tree root.
@@ -225,15 +238,24 @@ pub fn render_function_detail(f: &Function) -> String {
         for (i, p) in params.iter().enumerate() {
             let is_last = i == params.len() - 1;
             let connector = if is_last { "╰─" } else { "├─" };
-            let _ = writeln!(out, "{} {}", connector.dimmed(), format_abi_param(i, p));
+            let _ = writeln!(
+                out,
+                "{} {}",
+                connector.dimmed(),
+                format_abi_param(i, p, typedef_index)
+            );
         }
     }
 
     // Return value — always last child.
-    let ret_type = f.get_return_type_name().cyan();
-    let ret_loc = format_return_location(f.get_return_location());
-    let ret_styled = ret_loc.yellow();
-    let _ = writeln!(out, "{} {ret_styled}  {ret_type}", "╰".dimmed());
+    let ret_raw = f.get_return_type_name();
+    let ret_styled_cyan = ret_raw.cyan();
+    let ret_loc = format_return_location(f.get_return_location()).yellow();
+    let ret_cell = match typedef_annotation(ret_raw, None, typedef_index) {
+        Some(canon) => format!("{ret_styled_cyan} {}", format!("({canon})").dimmed()),
+        None => ret_styled_cyan.to_string(),
+    };
+    let _ = writeln!(out, "{} {ret_loc}  {ret_cell}", "╰".dimmed());
 
     out
 }

--- a/crates/bb-clang/src/display/mod.rs
+++ b/crates/bb-clang/src/display/mod.rs
@@ -11,6 +11,7 @@ mod constant;
 mod enum_;
 mod function;
 mod struct_;
+mod typedef;
 
 pub use bb_arch::display::register_name;
 pub use constant::render_constants;
@@ -20,7 +21,8 @@ pub use function::{
     format_return_location, format_tags, render_function_detail, render_function_item,
     render_function_list,
 };
-pub use struct_::{render_struct, typedef_annotation};
+pub use struct_::{render_struct, render_union, typedef_annotation};
+pub use typedef::format_typedef_summary;
 
 /// Render a type header line: styled name + optional type info +
 /// optional aliases chip + optional location.

--- a/crates/bb-clang/src/display/mod.rs
+++ b/crates/bb-clang/src/display/mod.rs
@@ -20,16 +20,21 @@ pub use function::{
     format_return_location, format_tags, render_function_detail, render_function_item,
     render_function_list,
 };
-pub use struct_::render_struct;
+pub use struct_::{render_struct, typedef_annotation};
 
-/// Render a type header line: styled name + optional type info + optional location.
+/// Render a type header line: styled name + optional type info +
+/// optional aliases chip + optional location.
 ///
-/// Anonymous names are dimmed; named types are cyan + bold.
+/// Anonymous names are dimmed; named types are cyan + bold. `type_name`,
+/// when given, is rendered in cyan (used for enum underlying-type tags).
+/// `aliases`, when non-empty, is rendered as a dim `[aka X, Y]` chip after
+/// the type info (used for struct typedef aliases).
 #[must_use]
 pub fn render_type_header(
     name: &str,
     is_anonymous: bool,
     type_name: Option<&str>,
+    aliases: &[String],
     location: Option<&SourceLocation>,
 ) -> String {
     let name_styled = if is_anonymous {
@@ -40,8 +45,13 @@ pub fn render_type_header(
     let type_info = type_name
         .map(|t| format!("  {}", t.cyan()))
         .unwrap_or_default();
+    let alias_chip = if aliases.is_empty() {
+        String::new()
+    } else {
+        format!("  {}", format!("[aka {}]", aliases.join(", ")).dimmed())
+    };
     let loc_info = location
         .map(|loc| format!(" {}", loc.to_string().dimmed()))
         .unwrap_or_default();
-    format!("{name_styled}{type_info}{loc_info}\n")
+    format!("{name_styled}{type_info}{alias_chip}{loc_info}\n")
 }

--- a/crates/bb-clang/src/display/struct_.rs
+++ b/crates/bb-clang/src/display/struct_.rs
@@ -8,6 +8,7 @@ use std::fmt::Write;
 use crate::ext::DeclarationKind;
 use crate::struct_::Field;
 use crate::struct_::Struct;
+use crate::typedef::TypedefIndex;
 
 /// Renders a struct in `WinDbg` `dt`-style format with Unicode box-drawing.
 ///
@@ -15,9 +16,25 @@ use crate::struct_::Struct;
 /// When recursing into a nested type, we add its name to the set; after returning,
 /// we remove it. This prevents infinite recursion while allowing the same type
 /// to appear in different branches.
+///
+/// `typedef_index`, when supplied, drives the dim `(canonical)` annotation
+/// next to each typedef'd field type — `HANDLE (void *)`, `PVOID (void *)`,
+/// `LARGE_INTEGER (_LARGE_INTEGER)`, etc. When `None`, falls back to the
+/// per-field `underlying_type` metadata, which covers struct typedefs only.
 #[must_use]
-pub fn render_struct(s: &Struct, depth: usize, field_filter: Option<&str>) -> String {
-    let mut out = super::render_type_header(s.get_name(), s.is_anonymous(), None, s.get_location());
+pub fn render_struct(
+    s: &Struct,
+    depth: usize,
+    field_filter: Option<&str>,
+    typedef_index: Option<&TypedefIndex>,
+) -> String {
+    let mut out = super::render_type_header(
+        s.get_name(),
+        s.is_anonymous(),
+        None,
+        s.get_aliases(),
+        s.get_location(),
+    );
 
     let mut seen = HashSet::new();
     seen.insert(s.get_name().to_string());
@@ -29,6 +46,7 @@ pub fn render_struct(s: &Struct, depth: usize, field_filter: Option<&str>) -> St
         "",
         field_filter,
         &mut seen,
+        typedef_index,
     );
 
     if let Some(size) = s.get_size() {
@@ -38,7 +56,38 @@ pub fn render_struct(s: &Struct, depth: usize, field_filter: Option<&str>) -> St
     out
 }
 
+/// Resolve the dim "(canonical)" annotation for a field type, if any.
+///
+/// Returns `None` when there is no annotation to render (type isn't a
+/// typedef, or canonical equals the displayed name). Centralized so the
+/// CLI, TUI, and function param renderers all use the same logic.
+#[must_use]
+pub fn typedef_annotation(
+    type_name: &str,
+    underlying_type: Option<&str>,
+    typedef_index: Option<&TypedefIndex>,
+) -> Option<String> {
+    // 1. Prefer the typedef index: works for any kind of typedef chain.
+    if let Some(idx) = typedef_index
+        && let Some(td) = idx.lookup(type_name)
+        && td.canonical != type_name
+    {
+        return Some(td.canonical.clone());
+    }
+
+    // 2. Fall back to the per-field underlying type: struct/union/enum only,
+    //    but still useful when no index is wired through.
+    if let Some(u) = underlying_type
+        && u != type_name
+    {
+        return Some(u.to_string());
+    }
+
+    None
+}
+
 /// Renders fields with Unicode box-drawing characters in a tree structure.
+#[allow(clippy::too_many_arguments)]
 fn write_fields(
     out: &mut String,
     fields: &[Field],
@@ -47,6 +96,7 @@ fn write_fields(
     prefix: &str,
     field_filter: Option<&str>,
     seen: &mut HashSet<String>,
+    typedef_index: Option<&TypedefIndex>,
 ) {
     let filtered: Vec<_> = fields
         .iter()
@@ -71,6 +121,25 @@ fn write_fields(
             name.white().bold()
         };
 
+        let type_cell = if let Some(name) = type_name {
+            let underlying = field.get_type_info().underlying_type.as_deref();
+            let annotation = typedef_annotation(name, underlying, typedef_index);
+            match annotation {
+                Some(canon) => format!("{} {}", name.cyan(), format!("({canon})").dimmed()),
+                None => name.cyan().to_string(),
+            }
+        } else {
+            format!(
+                "<anonymous {}>",
+                field
+                    .get_type()
+                    .get_declaration_kind_name()
+                    .unwrap_or("type")
+            )
+            .dimmed()
+            .to_string()
+        };
+
         let _ = writeln!(
             out,
             "{}{} {} {} {}  {}",
@@ -79,18 +148,7 @@ fn write_fields(
             offset.yellow(),
             format!("[{size}]").green(),
             name_styled,
-            if let Some(name) = type_name {
-                name.cyan()
-            } else {
-                format!(
-                    "<anonymous {}>",
-                    field
-                        .get_type()
-                        .get_declaration_kind_name()
-                        .unwrap_or("type")
-                )
-                .dimmed()
-            }
+            type_cell,
         );
 
         if current_depth < max_depth && field.has_children() {
@@ -113,6 +171,7 @@ fn write_fields(
                         &new_prefix,
                         None,
                         seen,
+                        typedef_index,
                     );
                 }
                 seen.remove(key);

--- a/crates/bb-clang/src/display/struct_.rs
+++ b/crates/bb-clang/src/display/struct_.rs
@@ -61,10 +61,17 @@ pub fn render_struct(
 /// Returns `None` when there is no annotation to render (type isn't a
 /// typedef, or canonical equals the displayed name). Centralized so the
 /// CLI, TUI, and function param renderers all use the same logic.
+///
+/// The fallback `underlying_record` arg is the record/enum decl name
+/// after stripping pointers/arrays (the "what struct is this?"
+/// answer) — kept as a fallback for when no [`TypedefIndex`] is supplied.
+/// The primitive `underlying_type` from [`TypeProperties`](crate::TypeProperties)
+/// isn't useful here because it loses pointer-ness (`HANDLE`'s primitive
+/// is `void`, but the user wants to see `void *`).
 #[must_use]
 pub fn typedef_annotation(
     type_name: &str,
-    underlying_type: Option<&str>,
+    underlying_record: Option<&str>,
     typedef_index: Option<&TypedefIndex>,
 ) -> Option<String> {
     // 1. Prefer the typedef index: works for any kind of typedef chain.
@@ -75,9 +82,9 @@ pub fn typedef_annotation(
         return Some(td.canonical.clone());
     }
 
-    // 2. Fall back to the per-field underlying type: struct/union/enum only,
-    //    but still useful when no index is wired through.
-    if let Some(u) = underlying_type
+    // 2. Fall back to the per-field underlying record: struct/union/enum
+    //    only, but still useful when no index is wired through.
+    if let Some(u) = underlying_record
         && u != type_name
     {
         return Some(u.to_string());
@@ -122,7 +129,7 @@ fn write_fields(
         };
 
         let type_cell = if let Some(name) = type_name {
-            let underlying = field.get_type_info().underlying_type.as_deref();
+            let underlying = field.get_type_info().underlying_record.as_deref();
             let annotation = typedef_annotation(name, underlying, typedef_index);
             match annotation {
                 Some(canon) => format!("{} {}", name.cyan(), format!("({canon})").dimmed()),

--- a/crates/bb-clang/src/display/struct_.rs
+++ b/crates/bb-clang/src/display/struct_.rs
@@ -9,6 +9,7 @@ use crate::ext::DeclarationKind;
 use crate::struct_::Field;
 use crate::struct_::Struct;
 use crate::typedef::TypedefIndex;
+use crate::union_::Union;
 
 /// Renders a struct in `WinDbg` `dt`-style format with Unicode box-drawing.
 ///
@@ -50,6 +51,46 @@ pub fn render_struct(
     );
 
     if let Some(size) = s.get_size() {
+        let _ = writeln!(out, "{}", format!("╰─ {size} bytes").dimmed());
+    }
+
+    out
+}
+
+/// Render a [`Union`] in the same tree style as [`render_struct`].
+///
+/// Mirrors `render_struct` field-for-field so `bb-types -s LARGE_INTEGER`
+/// produces a layout dump indistinguishable in structure from a struct
+/// render — the only material difference is the kind word in the header.
+#[must_use]
+pub fn render_union(
+    u: &Union,
+    depth: usize,
+    field_filter: Option<&str>,
+    typedef_index: Option<&TypedefIndex>,
+) -> String {
+    let mut out = super::render_type_header(
+        u.get_name(),
+        u.is_anonymous(),
+        None,
+        u.get_aliases(),
+        u.get_location(),
+    );
+
+    let mut seen = HashSet::new();
+    seen.insert(u.get_name().to_string());
+    write_fields(
+        &mut out,
+        u.get_fields(),
+        depth,
+        0,
+        "",
+        field_filter,
+        &mut seen,
+        typedef_index,
+    );
+
+    if let Some(size) = u.get_size() {
         let _ = writeln!(out, "{}", format!("╰─ {size} bytes").dimmed());
     }
 
@@ -122,7 +163,13 @@ fn write_fields(
         let name = field.get_name();
         let type_name = field.get_type_name();
 
-        let name_styled = if field_filter.is_some() {
+        // Synthetic names for nameless C-source fields are JSON-only
+        // identifiers — never shown in CLI/TUI. The `<anonymous union>`
+        // chip in the type column conveys the "this is anonymous"
+        // signal visually.
+        let name_styled = if field.is_anonymous() {
+            String::new().normal()
+        } else if field_filter.is_some() {
             name.white().bold().underline()
         } else {
             name.white().bold()
@@ -159,12 +206,19 @@ fn write_fields(
         );
 
         if current_depth < max_depth && field.has_children() {
-            let type_key = field
-                .get_underlying_type()
-                .get_declaration()
-                .and_then(|d| d.get_name());
+            // Use composite identity for anonymous fields (synthetic
+            // names alone collide across parents) and the underlying
+            // decl name for named ones.
+            let type_key = if let Some(aref) = field.get_anon_ref() {
+                Some(aref.identity())
+            } else {
+                field
+                    .get_underlying_type()
+                    .get_declaration()
+                    .and_then(|d| d.get_name())
+            };
 
-            if let Some(ref key) = type_key
+            if let Some(key) = type_key.as_ref()
                 && seen.insert(key.clone())
             {
                 let child_fields = field.get_child_fields();

--- a/crates/bb-clang/src/display/typedef.rs
+++ b/crates/bb-clang/src/display/typedef.rs
@@ -1,0 +1,28 @@
+//! Display rendering for [`Typedef`](crate::Typedef) entries.
+
+use colored::Colorize;
+
+use crate::typedef::Typedef;
+
+/// One-line summary for a typedef, used by `bb-types` to surface
+/// pointer/primitive typedefs that don't resolve to a record (so they
+/// have no `[aka …]` chip to ride on top of).
+///
+/// Example: `HANDLE  →  PVOID → void *   (pointer)  winnt.h:1234:5`.
+#[must_use]
+pub fn format_typedef_summary(t: &Typedef) -> String {
+    let name = t.name.cyan().bold();
+    let arrow_chain: String = t
+        .chain
+        .iter()
+        .map(String::as_str)
+        .collect::<Vec<_>>()
+        .join(" → ");
+    let kind = format!("({})", t.kind.label()).dimmed();
+    let loc = t
+        .location
+        .as_ref()
+        .map(|l| format!("  {}", l.to_string().dimmed()))
+        .unwrap_or_default();
+    format!("  {name}  →  {arrow_chain}   {kind}{loc}")
+}

--- a/crates/bb-clang/src/error.rs
+++ b/crates/bb-clang/src/error.rs
@@ -18,13 +18,17 @@ pub enum StructError {
 }
 
 #[derive(Debug, Error)]
+pub enum UnionError {
+    #[error("Entity is not a union: {0:?}")]
+    NotUnion(EntityKind),
+}
+
+#[derive(Debug, Error)]
 pub enum FieldError {
     #[error("Entity is not a field: {0:?}")]
     NotField(EntityKind),
     #[error("Entity does not have a type")]
     NoType,
-    #[error("Entity does not have a name")]
-    NoName,
     #[error("Entity's type does not have a size")]
     NoSize,
     #[error("Entity's type does not contain a field named {0} to get the offset of")]
@@ -91,6 +95,8 @@ pub enum Error {
     SourceLocation(#[from] SourceLocationError),
     #[error("Struct error: {0}")]
     Struct(#[from] StructError),
+    #[error("Union error: {0}")]
+    Union(#[from] UnionError),
     #[error("Field error: {0}")]
     Field(#[from] FieldError),
     #[error("Enum error: {0}")]

--- a/crates/bb-clang/src/function/mod.rs
+++ b/crates/bb-clang/src/function/mod.rs
@@ -89,9 +89,13 @@ impl<'a> Function<'a> {
     }
 
     /// Render a detailed ABI breakdown.
+    ///
+    /// Pass an optional [`TypedefIndex`](crate::TypedefIndex) to annotate
+    /// typedef'd param/return types with their canonical form. `None`
+    /// leaves the signature unannotated.
     #[must_use]
-    pub fn display_detail(&self) -> String {
-        crate::display::render_function_detail(self)
+    pub fn display_detail(&self, typedef_index: Option<&crate::TypedefIndex>) -> String {
+        crate::display::render_function_detail(self, typedef_index)
     }
 }
 

--- a/crates/bb-clang/src/json.rs
+++ b/crates/bb-clang/src/json.rs
@@ -9,6 +9,7 @@ use crate::enum_::Enum;
 use crate::function::{Function, Param};
 use crate::struct_::Field;
 use crate::struct_::Struct;
+use crate::union_::Union;
 
 /// Maximum nesting depth for full struct expansion.
 const MAX_DEPTH: usize = 8;
@@ -34,8 +35,6 @@ impl ToJson for Constant<'_> {
         serde_json::to_value(self).unwrap()
     }
 
-    /// Like [`to_json`](ToJson::to_json) but with a `referred_components` field
-    /// containing the fully serialized component constants.
     fn to_json_full(&self) -> Value {
         let mut val = self.to_json();
         val.as_object_mut().unwrap().insert(
@@ -74,30 +73,55 @@ impl ToJson for Param<'_> {
 }
 
 impl ToJson for Struct<'_> {
-    /// Serializes the struct with `referenced_types` as a list of type names.
+    /// Basic serialization. Adds `referenced_types` as a name-string
+    /// array of every *named* referenced record (struct or union).
+    /// Anonymous nested records have no name to put in a string list
+    /// — they're only emitted by [`Self::to_json_full`].
     fn to_json(&self) -> Value {
         let mut val = serde_json::to_value(self).unwrap();
-        val.as_object_mut().unwrap().insert(
+        let obj = val.as_object_mut().unwrap();
+        obj.insert(
             "referenced_types".to_string(),
             serde_json::to_value(self.referenced_type_names()).unwrap(),
         );
         val
     }
 
-    /// Returns `{ "type": {..}, "referenced_types": [{..}, ..] }` where
-    /// `referenced_types` contains fully expanded nested types up to
-    /// [`MAX_DEPTH`], each with their own `referenced_types` name list.
+    /// Full serialization. Emits the struct itself under `"type"` and
+    /// a `referenced_types` array of full objects — both structs and
+    /// unions, named or anonymous, distinguished per-entry by `"kind"`.
     fn to_json_full(&self) -> Value {
-        let mut seen = HashSet::new();
-        seen.insert(self.get_name().to_string());
-
-        let referenced: Vec<Value> = self
-            .extract_nested_types(MAX_DEPTH)
-            .into_iter()
-            .filter(|n| seen.insert(n.get_name().to_string()))
-            .map(|n| serde_json::to_value(n).unwrap())
+        let (structs, unions) = self.extract_nested_records(MAX_DEPTH);
+        let referenced: Vec<Value> = structs
+            .iter()
+            .map(|s| serde_json::to_value(s).unwrap())
+            .chain(unions.iter().map(|u| serde_json::to_value(u).unwrap()))
             .collect();
+        serde_json::json!({
+            "type": serde_json::to_value(self).unwrap(),
+            "referenced_types": referenced,
+        })
+    }
+}
 
+impl ToJson for Union<'_> {
+    fn to_json(&self) -> Value {
+        let mut val = serde_json::to_value(self).unwrap();
+        let obj = val.as_object_mut().unwrap();
+        obj.insert(
+            "referenced_types".to_string(),
+            serde_json::to_value(self.referenced_type_names()).unwrap(),
+        );
+        val
+    }
+
+    fn to_json_full(&self) -> Value {
+        let (structs, unions) = self.extract_nested_records(MAX_DEPTH);
+        let referenced: Vec<Value> = structs
+            .iter()
+            .map(|s| serde_json::to_value(s).unwrap())
+            .chain(unions.iter().map(|u| serde_json::to_value(u).unwrap()))
+            .collect();
         serde_json::json!({
             "type": serde_json::to_value(self).unwrap(),
             "referenced_types": referenced,
@@ -123,12 +147,6 @@ impl ToJson for [Constant<'_>] {
         slice_to_json(self)
     }
 
-    /// Returns `{ "constants": [...], "referred_components": [...] }`.
-    ///
-    /// `referred_components` is a deduplicated, depth-first list of all
-    /// [`Constant`]s that are transitively referenced as components by the
-    /// constants in this slice. Constants already present in the slice are
-    /// excluded from `referred_components`.
     fn to_json_full(&self) -> Value {
         let mut seen: HashSet<String> = self.iter().map(|c| c.get_name().to_string()).collect();
         let mut referred = Vec::new();
@@ -184,26 +202,34 @@ impl ToJson for [Param<'_>] {
 
 /// `to_json` produces an array of structs.
 /// `to_json_full` produces `{ "types": [...], "referenced_types": [...] }`
-/// with all nested types across the slice expanded up to [`MAX_DEPTH`]
-/// and deduplicated.
+/// where `referenced_types` mixes structs and unions discovered through
+/// any field of the slice's records (recursively up to [`MAX_DEPTH`],
+/// deduplicated by composite identity). Each entry carries `"kind"` so
+/// the consumer can dispatch.
 impl ToJson for [Struct<'_>] {
     fn to_json(&self) -> Value {
         slice_to_json(self)
     }
 
     fn to_json_full(&self) -> Value {
-        let mut seen: HashSet<String> = self.iter().map(|s| s.get_name().to_string()).collect();
+        let mut seen: HashSet<String> = self.iter().map(|s| s.identity()).collect();
 
         let types: Vec<Value> = self
             .iter()
             .map(|s| serde_json::to_value(s).unwrap())
             .collect();
 
-        let mut referenced = Vec::new();
+        let mut referenced: Vec<Value> = Vec::new();
         for s in self {
-            for nested in s.extract_nested_types(MAX_DEPTH) {
-                if seen.insert(nested.get_name().to_string()) {
-                    referenced.push(serde_json::to_value(&nested).unwrap());
+            let (nested_structs, nested_unions) = s.extract_nested_records(MAX_DEPTH);
+            for ns in nested_structs {
+                if seen.insert(ns.identity()) {
+                    referenced.push(serde_json::to_value(&ns).unwrap());
+                }
+            }
+            for nu in nested_unions {
+                if seen.insert(nu.identity()) {
+                    referenced.push(serde_json::to_value(&nu).unwrap());
                 }
             }
         }
@@ -243,23 +269,85 @@ where
 
 /* ───────────────────────────────── Helpers ──────────────────────────────── */
 
-/// Helper: map each element's `T::to_json` into a JSON array.
 fn slice_to_json<T: ToJson>(slice: &[T]) -> Value {
     Value::Array(slice.iter().map(T::to_json).collect())
 }
 
-/// Helper: map each element's `T::to_json` into a JSON array.
 fn slice_to_json_full<T: ToJson>(slice: &[T]) -> Value {
     Value::Array(slice.iter().map(T::to_json_full).collect())
 }
 
+/* ─────────────────────── Mixed struct + union helper ───────────────────── */
+
+/// Full JSON shape for a heterogeneous set of records (some structs,
+/// some unions). Used by `bb-types` and any other consumer that wants
+/// to dump struct and union queries together.
+///
+/// Returns:
+/// ```jsonc
+/// {
+///   "types":            [ /* structs first, then unions; each carries "kind" */ ],
+///   "referenced_types": [ /* every record reachable via fields, dedup'd by composite identity */ ]
+/// }
+/// ```
+///
+/// Each entry in `referenced_types` carries `"kind"` ("struct" /
+/// "union") so consumers can dispatch. Anonymous nested entries
+/// additionally carry `enclosing_record` + `field_path` for
+/// cross-reference from a parent's anon-typed field.
+#[must_use]
+pub fn records_to_json_full(structs: &[Struct<'_>], unions: &[Union<'_>]) -> Value {
+    let mut types: Vec<Value> = structs
+        .iter()
+        .map(|s| serde_json::to_value(s).expect("Struct serializes"))
+        .collect();
+    types.extend(
+        unions
+            .iter()
+            .map(|u| serde_json::to_value(u).expect("Union serializes")),
+    );
+
+    let mut seen: HashSet<String> = structs
+        .iter()
+        .map(Struct::identity)
+        .chain(unions.iter().map(Union::identity))
+        .collect();
+    let mut referenced: Vec<Value> = Vec::new();
+    for s in structs {
+        let (ns, nu) = s.extract_nested_records(MAX_DEPTH);
+        extend_referenced_records(ns, nu, &mut seen, &mut referenced);
+    }
+    for u in unions {
+        let (ns, nu) = u.extract_nested_records(MAX_DEPTH);
+        extend_referenced_records(ns, nu, &mut seen, &mut referenced);
+    }
+
+    serde_json::json!({
+        "types": types,
+        "referenced_types": referenced,
+    })
+}
+
+fn extend_referenced_records(
+    structs: Vec<Struct<'_>>,
+    unions: Vec<Union<'_>>,
+    seen: &mut HashSet<String>,
+    out: &mut Vec<Value>,
+) {
+    for r in structs {
+        if seen.insert(r.identity()) {
+            out.push(serde_json::to_value(&r).expect("Struct serializes"));
+        }
+    }
+    for r in unions {
+        if seen.insert(r.identity()) {
+            out.push(serde_json::to_value(&r).expect("Union serializes"));
+        }
+    }
+}
+
 /* ──────────────────────────── Component helpers ─────────────────────────── */
 
-/// Collect the `referred_components` array for a `to_json_full` result.
-///
-/// Seeds a `seen` set from `primary_names`, then transitively collects all
-/// component constants referenced by `constants` (depth-first, deduplicated).
-/// Returns an empty `Vec` when there are no referred components.
 pub fn build_referred_components<'a>(
     primary_names: impl IntoIterator<Item = String>,
     constants: impl IntoIterator<Item = &'a Constant<'a>>,
@@ -272,18 +360,12 @@ pub fn build_referred_components<'a>(
     referred
 }
 
-/// Recursively collect all [`Constant`]s transitively referenced as components,
-/// depth-first (dependencies before dependents), deduplicating via `seen`.
-///
-/// Constants whose names are already in `seen` (i.e. already in the main
-/// result set or already collected) are skipped.
 pub fn collect_component_constants(
     c: &Constant,
     seen: &mut HashSet<String>,
     result: &mut Vec<Value>,
 ) {
     for comp in c.get_component_constants() {
-        // Recurse into this component's own dependencies first.
         collect_component_constants(comp, seen, result);
         if seen.insert(comp.get_name().to_string()) {
             result.push(comp.to_json());

--- a/crates/bb-clang/src/lib.rs
+++ b/crates/bb-clang/src/lib.rs
@@ -14,11 +14,13 @@ mod enum_;
 mod error;
 mod ext;
 mod function;
-mod json;
+pub mod json;
 pub(crate) mod location;
+mod record;
 mod struct_;
 mod type_info;
 mod typedef;
+mod union_;
 
 pub use constant::{
     ConstLookup, ConstValue, Constant, MacroBodyToken, StripOuterParens, TuEntityMap,
@@ -28,14 +30,19 @@ pub use display::render_constants;
 pub use enum_::Enum;
 pub use error::{
     ConstantError, EnumError, FieldError, FunctionError, SourceLocationError, StructError,
+    UnionError,
 };
 pub use function::{CallConv, Function, Param};
-pub use json::{ToJson, build_referred_components, collect_component_constants};
+pub use json::{
+    ToJson, build_referred_components, collect_component_constants, records_to_json_full,
+};
 pub use location::{SourceLocation, entity_in_header};
+pub use record::{AnonRef, RecordKind};
 pub use struct_::Field;
 pub use struct_::Struct;
 pub use type_info::{TypeInfo, TypeProperties};
 pub use typedef::{Typedef, TypedefIndex, TypedefKind};
+pub use union_::Union;
 
 // Re-export commonly used clang types for convenience
 pub use clang::{Entity, EntityKind, Index, TranslationUnit, Unsaved};

--- a/crates/bb-clang/src/lib.rs
+++ b/crates/bb-clang/src/lib.rs
@@ -34,7 +34,7 @@ pub use json::{ToJson, build_referred_components, collect_component_constants};
 pub use location::{SourceLocation, entity_in_header};
 pub use struct_::Field;
 pub use struct_::Struct;
-pub use type_info::TypeInfo;
+pub use type_info::{TypeInfo, TypeProperties};
 pub use typedef::{Typedef, TypedefIndex, TypedefKind};
 
 // Re-export commonly used clang types for convenience

--- a/crates/bb-clang/src/lib.rs
+++ b/crates/bb-clang/src/lib.rs
@@ -18,6 +18,7 @@ mod json;
 pub(crate) mod location;
 mod struct_;
 mod type_info;
+mod typedef;
 
 pub use constant::{
     ConstLookup, ConstValue, Constant, MacroBodyToken, StripOuterParens, TuEntityMap,
@@ -34,6 +35,7 @@ pub use location::{SourceLocation, entity_in_header};
 pub use struct_::Field;
 pub use struct_::Struct;
 pub use type_info::TypeInfo;
+pub use typedef::{Typedef, TypedefIndex, TypedefKind};
 
 // Re-export commonly used clang types for convenience
 pub use clang::{Entity, EntityKind, Index, TranslationUnit, Unsaved};

--- a/crates/bb-clang/src/record.rs
+++ b/crates/bb-clang/src/record.rs
@@ -1,0 +1,65 @@
+//! Shared building blocks for record (struct + union) representation.
+//!
+//! [`RecordKind`] is the type-level discriminator that lives on every
+//! record JSON entry — top-level [`Struct`](crate::Struct), top-level
+//! [`Union`](crate::Union), or any anonymous nested record surfaced in a
+//! struct's `referenced_structs` / `referenced_unions` slot. Consumers
+//! switch on `kind` to dispatch reconstruction.
+//!
+//! [`AnonRef`] is the cross-reference an anonymous nested record gets
+//! from the field that points at it. The pair
+//! `(enclosing_record, field_path)` is the canonical identity for an
+//! anonymous record across the JSON output: `enclosing_record` is always
+//! a named ancestor (walked via `semantic_parent`), `field_path` is the
+//! chain of field names from that named ancestor down to this record.
+//! Anonymous fields along the way carry a synthetic name of the form
+//! `<anonymous_N>` where `N` is the per-parent counter — see
+//! [`crate::Field`] for how the counter is assigned.
+
+use serde::Serialize;
+
+/* ────────────────────────────────── Types ───────────────────────────────── */
+
+/// Discriminates struct-shaped records from union-shaped records.
+///
+/// Serializes as `"struct"` / `"union"` in JSON. Top-level
+/// [`Struct`](crate::Struct) entries always carry `Struct`;
+/// [`Union`](crate::Union) entries always carry `Union`. Anonymous
+/// nested records carry whichever they actually are — the same record
+/// type can model either depending on the underlying clang decl.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RecordKind {
+    Struct,
+    Union,
+}
+
+/// Cross-reference to an anonymous record nested inside a named record.
+///
+/// Set on a [`Field`](crate::Field) when the field's underlying type is
+/// an anonymous struct or union. The tuple `(kind, enclosing_record,
+/// field_path)` is the lookup key for the matching entry in the parent
+/// struct's `referenced_structs` or `referenced_unions` slot —
+/// `kind` picks the slot, `(enclosing_record, field_path)` picks the
+/// entry within it.
+///
+/// `field_path` uses synthetic `<anonymous_N>` names for any
+/// intermediate anonymous fields along the way. For OVERLAPPED's nested
+/// anonymous struct, the path is `["<anonymous_0>", "<anonymous_0>"]`
+/// — the outer 0 indexes the union field within `_OVERLAPPED`, the
+/// inner 0 indexes the struct field within that union.
+#[derive(Debug, Clone, Serialize)]
+pub struct AnonRef {
+    pub kind: RecordKind,
+    pub enclosing_record: String,
+    pub field_path: Vec<String>,
+}
+
+impl AnonRef {
+    /// Stable composite identity string. Used as a `HashSet` key when
+    /// deduplicating anonymous records during nested-record extraction.
+    #[must_use]
+    pub fn identity(&self) -> String {
+        format!("{}::{}", self.enclosing_record, self.field_path.join("::"))
+    }
+}

--- a/crates/bb-clang/src/struct_/field.rs
+++ b/crates/bb-clang/src/struct_/field.rs
@@ -66,23 +66,29 @@ pub struct Field<'a> {
 impl<'a> Field<'a> {
     /// The underlying clang entity this `Field` was built from.
     ///
-    /// **Contract**: returns a [`EntityKind::FieldDecl`] for fields
-    /// constructed from a real C field declaration, OR a
-    /// [`EntityKind::StructDecl`] / [`EntityKind::UnionDecl`] /
-    /// [`EntityKind::ClassDecl`] for synthetic entries representing
-    /// anonymous nested records that appear as sibling decls (the
-    /// `DUMMYUNIONNAME`-expands-to-empty pattern under default MSVC
-    /// parsing). Use [`Self::get_field_decl`] when only a FieldDecl
-    /// will do, or check [`Self::is_anonymous`] / [`Self::get_anon_ref`]
-    /// to discriminate.
+    /// Contract — two cases:
+    ///
+    /// 1. A [`EntityKind::FieldDecl`] for fields built from a real C
+    ///    field declaration.
+    ///
+    /// 2. A [`EntityKind::StructDecl`] / [`EntityKind::UnionDecl`] /
+    ///    [`EntityKind::ClassDecl`] for synthetic entries representing
+    ///    anonymous nested records that appear as sibling decls (the
+    ///    `DUMMYUNIONNAME`-expands-to-empty pattern under default MSVC
+    ///    parsing).
+    ///
+    /// Use [`Self::get_field_decl`] when only a `FieldDecl` will do,
+    /// or check [`Self::is_anonymous`] / [`Self::get_anon_ref`] to
+    /// discriminate.
     #[must_use]
     pub const fn get_entity(&self) -> &Entity<'a> {
         &self.entity
     }
-    /// The FieldDecl this field was built from, if any.
+
+    /// The `FieldDecl` this field was built from, if any.
     ///
-    /// Returns `None` for synthetic anon-record entries — those have
-    /// no FieldDecl in clang's AST and store the record decl in
+    /// Returns `None` for synthetic anon-record entries: those have
+    /// no `FieldDecl` in clang's AST and store the record decl in
     /// [`Self::get_entity`] instead.
     #[must_use]
     pub fn get_field_decl(&self) -> Option<&Entity<'a>> {
@@ -92,10 +98,15 @@ impl<'a> Field<'a> {
             None
         }
     }
-    /// Semantic parent of this field. For real FieldDecls this is the
-    /// enclosing record; for synthetic anon-record entries this is
-    /// also the enclosing record (the anon record's
-    /// `semantic_parent`). Always meaningful in both cases.
+
+    /// Semantic parent of this field — always the enclosing record.
+    ///
+    /// Real `FieldDecl`s: clang reports the enclosing record directly.
+    ///
+    /// Synthetic anon-record entries: the anon record's own
+    /// `semantic_parent` resolves to the same enclosing record (because
+    /// the anon decl was visited as a child of that record in
+    /// `collect_fields`).
     #[must_use]
     pub const fn get_semantic_parent(&self) -> &Entity<'a> {
         &self.semantic_parent
@@ -165,11 +176,14 @@ impl<'a> Field<'a> {
         self.get_underlying_type().has_children()
     }
 
-    /// Classify the record kind of this field's underlying type, if
-    /// any. Returns `None` when the field's type isn't a record (it's
-    /// a primitive, function pointer, or unresolvable). Drives kind
-    /// dispatch in nested-record walkers without going through the
-    /// fallible `get_child_struct` / `get_child_union` constructors.
+    /// Classify the record kind of this field's underlying type.
+    ///
+    /// Returns `None` when the field's type isn't a record — it's a
+    /// primitive, a function pointer, or otherwise unresolvable.
+    ///
+    /// Drives kind dispatch in nested-record walkers without going
+    /// through the fallible `get_child_struct` / `get_child_union`
+    /// constructors.
     #[must_use]
     pub fn record_kind(&self) -> Option<RecordKind> {
         let decl = self.get_underlying_type().get_declaration()?;
@@ -180,9 +194,11 @@ impl<'a> Field<'a> {
         }
     }
 
-    /// The struct/class declaration this field's underlying type points
-    /// at, if any. Returns `None` for unions or non-record types — use
-    /// [`Self::get_child_union`] for unions.
+    /// The struct/class declaration this field's underlying type
+    /// points at, if any.
+    ///
+    /// Returns `None` for unions or non-record types.
+    /// Use [`Self::get_child_union`] for unions.
     #[must_use]
     pub fn get_child_struct(&self) -> Option<Struct<'a>> {
         let underlying = self.get_underlying_type();
@@ -202,12 +218,15 @@ impl<'a> Field<'a> {
         Struct::try_from(decl).ok()
     }
 
-    /// Collect the child fields of this field's underlying record
-    /// declaration, with anon-context inherited from this field's
-    /// [`AnonRef`] when present. Used by the display layer for inline
-    /// tree expansion.
+    /// Collect the child fields of this field's underlying record.
     ///
-    /// Returns an empty `Vec` when the underlying type isn't a record.
+    /// When this field carries an [`AnonRef`], the anon context
+    /// (enclosing record + field path) is inherited, so any synthetic
+    /// names assigned to grand-child anon decls continue to use a
+    /// consistent path prefix.
+    ///
+    /// Used by the display layer for inline tree expansion. Returns
+    /// an empty `Vec` when the underlying type isn't a record.
     #[must_use]
     pub fn get_child_fields(&self) -> Vec<Self> {
         let underlying = self.get_underlying_type();
@@ -231,8 +250,10 @@ impl<'a> Field<'a> {
     }
 
     /// The union declaration this field's underlying type points at,
-    /// if any. Returns `None` for structs or non-record types — use
-    /// [`Self::get_child_struct`] for structs.
+    /// if any.
+    ///
+    /// Returns `None` for structs or non-record types.
+    /// Use [`Self::get_child_struct`] for structs.
     #[must_use]
     pub fn get_child_union(&self) -> Option<Union<'a>> {
         let underlying = self.get_underlying_type();
@@ -254,20 +275,25 @@ impl<'a> Field<'a> {
 
 /// Collects all field declarations from a struct/class/union entity.
 ///
-/// `enclosing_record` is the outermost named ancestor's display name —
-/// for top-level records, the record's own name; for nested anonymous
-/// records, the same name propagated through the walk. `parent_path`
-/// is the chain of field names from `enclosing_record` down to (but
-/// not including) `parent` — empty at the top level.
+/// `enclosing_record` is the outermost named ancestor's display name.
+/// For a top-level record this is the record's own name; for nested
+/// anonymous records the same name propagates through the walk.
 ///
-/// Nameless members are accepted: each one gets a synthetic name
-/// `<anonymous_N>`. Two independent per-parent counters are
-/// maintained — one for nameless `FieldDecl`s and one for sibling
-/// anon-record decls (`StructDecl`/`UnionDecl`/`ClassDecl` with no
-/// surrounding FieldDecl) — so an ordering shuffle in clang's child
-/// visit order can't perturb existing identities. Both counters
-/// reset per `collect_fields` call, which matches the per-parent
-/// scoping in the JSON `field_path` semantics.
+/// `parent_path` is the chain of field names from `enclosing_record`
+/// down to (but not including) `parent`. Empty at the top level.
+///
+/// Nameless members are accepted with a synthetic name `<anonymous_N>`.
+/// Two independent per-parent counters drive the index `N`:
+///
+/// - `nameless_field_idx` — bumps for nameless `FieldDecl`s.
+/// - `sibling_decl_idx` — bumps for sibling anon-record decls
+///   (`StructDecl` / `UnionDecl` / `ClassDecl` with no enclosing
+///   FieldDecl).
+///
+/// Splitting the counters means an ordering shuffle in clang's child
+/// visit order can't perturb existing identities. Both counters reset
+/// per `collect_fields` call, matching the per-parent scoping in the
+/// JSON `field_path` semantics.
 #[must_use]
 pub fn collect_fields<'a>(
     parent: &Entity<'a>,
@@ -275,8 +301,9 @@ pub fn collect_fields<'a>(
     parent_path: &[String],
 ) -> Vec<Field<'a>> {
     let mut fields = Vec::new();
-    let mut nameless_field_idx = 0_usize;
-    let mut sibling_decl_idx = 0_usize;
+    let mut nameless_field_idx: usize = 0;
+    let mut sibling_decl_idx: usize = 0;
+
     parent.visit_children(|child, _| {
         match child.get_kind() {
             EntityKind::FieldDecl => {
@@ -299,14 +326,18 @@ pub fn collect_fields<'a>(
                     fields.push(field);
                 }
             }
-            // Anonymous nested record decls appear as direct children
-            // of the parent (siblings of FieldDecl) — this is how
-            // clang models the C macro pattern
-            // `union { ... } DUMMYUNIONNAME;` where the field name
-            // expands to empty under default MSVC parsing. We
-            // synthesize a Field for these so they appear in the
-            // layout at the right offset with an `anon_ref` into the
-            // referenced_unions / referenced_structs slot.
+
+            // Sibling anonymous record decls.
+            //
+            // Clang represents `union { ... } DUMMYUNIONNAME;` (where
+            // the macro expands to empty under default MSVC parsing) as
+            // an anonymous `UnionDecl` child of the parent struct — no
+            // wrapping `FieldDecl`.
+            //
+            // We synthesize a Field for each so the anon record shows
+            // up at its real offset in the parent's layout, with an
+            // `anon_ref` pointing into the parent's `referenced_types`
+            // slot for the body.
             EntityKind::StructDecl | EntityKind::ClassDecl | EntityKind::UnionDecl
                 if child.is_anonymous() =>
             {
@@ -318,10 +349,12 @@ pub fn collect_fields<'a>(
                     fields.push(field);
                 }
             }
+
             _ => {}
         }
         EntityVisitResult::Continue
     });
+
     fields
 }
 
@@ -457,15 +490,21 @@ fn build_anon_record_field<'a>(
     })
 }
 
-/// Walk the anonymous record's children for any reachable named
-/// member and use that member's offset in the parent as the anon
-/// record's own offset. Recurses through nested anonymous records
-/// (which is exactly the OVERLAPPED case — an anon union containing
-/// an anon struct whose `Offset` member is the first reachable
-/// named field).
+/// Compute the bit-offset of an anonymous record inside its parent.
 ///
-/// Returns the offset in bits (libclang's `get_offsetof` unit) or
-/// `None` if no reachable named member exists.
+/// Strategy: walk the anon record's children for any reachable named
+/// member, then ask the parent type for that member's offset. Under
+/// default MSVC parsing the anon record's members are hoisted into
+/// the parent's namespace, so the answer equals the anon record's
+/// own offset.
+///
+/// Recurses through nested anonymous records — the OVERLAPPED case
+/// (anon union → anon struct → `Offset`) bottoms out on the named
+/// `Offset` field even though every intermediate record is nameless.
+///
+/// Returns the offset in bits (libclang's `get_offsetof` unit), or
+/// `None` if no reachable named member exists. The caller treats
+/// `None` as a build failure rather than substituting zero.
 fn anon_record_offset_in_parent(
     parent_type: &clang::Type<'_>,
     anon_decl: &Entity<'_>,

--- a/crates/bb-clang/src/struct_/field.rs
+++ b/crates/bb-clang/src/struct_/field.rs
@@ -1,13 +1,22 @@
 //! Field type representation.
 //!
 //! Each field embeds a [`TypeInfo`](crate::TypeInfo) for shared type
-//! classification (pointer, array, const, underlying type).
+//! classification (pointer, array, const, underlying type). Nameless
+//! fields — typical of OVERLAPPED-style anonymous unions/structs in
+//! Windows headers under default MSVC parsing — are accepted: their
+//! [`Field::name`] is a synthetic `<anonymous_N>` (per-parent counter)
+//! and [`Field::is_anonymous`] is set. When the field's underlying
+//! declaration is itself anonymous, [`Field::anon_ref`] cross-references
+//! the entry in the parent struct's `referenced_structs` /
+//! `referenced_unions` slot.
 
 use crate::error::FieldError;
 use crate::ext::{AnonymousType, HasChildrenType};
 use crate::location::SourceLocation;
+use crate::record::{AnonRef, RecordKind};
 use crate::type_info::TypeInfo;
-use clang::{Entity, EntityKind, Type};
+use crate::union_::Union;
+use clang::{Entity, EntityKind, EntityVisitResult, Type};
 use serde::Serialize;
 
 use super::Struct;
@@ -19,13 +28,32 @@ pub struct Field<'a> {
     #[serde(skip)]
     entity: Entity<'a>,
     #[serde(skip)]
-    #[allow(unused)]
     semantic_parent: Entity<'a>,
+    /// Field name. For C-source nameless fields (the result of
+    /// `DUMMYUNIONNAME` / `DUMMYSTRUCTNAME` macros expanding to empty
+    /// under default MSVC parsing) this is a synthetic
+    /// `<anonymous_N>` where `N` is the index among the parent
+    /// record's nameless siblings only. The angle brackets make the
+    /// synthetic name lexically impossible to mistake for a real C
+    /// identifier.
     name: String,
     #[serde(rename = "type")]
     type_name: Option<String>,
     #[serde(flatten)]
     type_info: TypeInfo<'a>,
+    /// `true` when this field has no name in the C source. The display
+    /// layer suppresses the synthetic name; the JSON layer keeps it as
+    /// the cross-reference key. Consumers use this flag to drop the
+    /// field name when reconstructing C source.
+    #[serde(skip_serializing_if = "std::ops::Not::not")]
+    is_anonymous: bool,
+    /// Cross-reference into the parent struct's `referenced_structs` /
+    /// `referenced_unions` slot. Set when the field's underlying
+    /// declaration is an anonymous record. The pair
+    /// `(enclosing_record, field_path)` selects the matching record
+    /// entry; `kind` picks the slot.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    anon_ref: Option<AnonRef>,
     location: Option<SourceLocation>,
     #[serde(rename = "offset_bits")]
     offset: usize,
@@ -36,11 +64,38 @@ pub struct Field<'a> {
 }
 
 impl<'a> Field<'a> {
+    /// The underlying clang entity this `Field` was built from.
+    ///
+    /// **Contract**: returns a [`EntityKind::FieldDecl`] for fields
+    /// constructed from a real C field declaration, OR a
+    /// [`EntityKind::StructDecl`] / [`EntityKind::UnionDecl`] /
+    /// [`EntityKind::ClassDecl`] for synthetic entries representing
+    /// anonymous nested records that appear as sibling decls (the
+    /// `DUMMYUNIONNAME`-expands-to-empty pattern under default MSVC
+    /// parsing). Use [`Self::get_field_decl`] when only a FieldDecl
+    /// will do, or check [`Self::is_anonymous`] / [`Self::get_anon_ref`]
+    /// to discriminate.
     #[must_use]
     pub const fn get_entity(&self) -> &Entity<'a> {
         &self.entity
     }
-    #[allow(unused)]
+    /// The FieldDecl this field was built from, if any.
+    ///
+    /// Returns `None` for synthetic anon-record entries — those have
+    /// no FieldDecl in clang's AST and store the record decl in
+    /// [`Self::get_entity`] instead.
+    #[must_use]
+    pub fn get_field_decl(&self) -> Option<&Entity<'a>> {
+        if self.entity.get_kind() == EntityKind::FieldDecl {
+            Some(&self.entity)
+        } else {
+            None
+        }
+    }
+    /// Semantic parent of this field. For real FieldDecls this is the
+    /// enclosing record; for synthetic anon-record entries this is
+    /// also the enclosing record (the anon record's
+    /// `semantic_parent`). Always meaningful in both cases.
     #[must_use]
     pub const fn get_semantic_parent(&self) -> &Entity<'a> {
         &self.semantic_parent
@@ -85,96 +140,390 @@ impl<'a> Field<'a> {
     pub const fn get_alignment(&self) -> usize {
         self.alignment
     }
+    #[must_use]
+    pub const fn is_anonymous(&self) -> bool {
+        self.is_anonymous
+    }
+    /// Cross-reference into the parent record's `referenced_structs` /
+    /// `referenced_unions` slot. `Some` only when the field's
+    /// underlying type is an anonymous record.
+    #[must_use]
+    pub const fn get_anon_ref(&self) -> Option<&AnonRef> {
+        self.anon_ref.as_ref()
+    }
 
     /// Returns the underlying type of this field, resolving pointers and arrays.
-    ///
-    /// For pointer types like `PLIST_ENTRY`, this returns the pointee type (`LIST_ENTRY`).
-    /// For array types, this returns the element type. Otherwise returns the canonical type.
     #[must_use]
     pub fn get_underlying_type(&self) -> Type<'a> {
         self.type_info.get_underlying_type()
     }
 
-    /// Returns true if this field's underlying type has child fields that can be expanded.
+    /// Returns true if this field's underlying type has child fields
+    /// that can be expanded.
     #[must_use]
     pub fn has_children(&self) -> bool {
         self.get_underlying_type().has_children()
     }
 
+    /// Classify the record kind of this field's underlying type, if
+    /// any. Returns `None` when the field's type isn't a record (it's
+    /// a primitive, function pointer, or unresolvable). Drives kind
+    /// dispatch in nested-record walkers without going through the
+    /// fallible `get_child_struct` / `get_child_union` constructors.
     #[must_use]
-    pub fn get_child_fields(&self) -> Vec<Self> {
-        self.get_underlying_type()
-            .get_declaration()
-            .map(|decl| collect_fields(&decl))
-            .unwrap_or_default()
+    pub fn record_kind(&self) -> Option<RecordKind> {
+        let decl = self.get_underlying_type().get_declaration()?;
+        match decl.get_kind() {
+            EntityKind::StructDecl | EntityKind::ClassDecl => Some(RecordKind::Struct),
+            EntityKind::UnionDecl => Some(RecordKind::Union),
+            _ => None,
+        }
     }
 
+    /// The struct/class declaration this field's underlying type points
+    /// at, if any. Returns `None` for unions or non-record types — use
+    /// [`Self::get_child_union`] for unions.
     #[must_use]
     pub fn get_child_struct(&self) -> Option<Struct<'a>> {
         let underlying = self.get_underlying_type();
         let decl = underlying.get_declaration()?;
+        if !matches!(
+            decl.get_kind(),
+            EntityKind::StructDecl | EntityKind::ClassDecl
+        ) {
+            return None;
+        }
+        if let Some(aref) = &self.anon_ref
+            && aref.kind == RecordKind::Struct
+        {
+            return Struct::from_anon(decl, aref.enclosing_record.clone(), aref.field_path.clone())
+                .ok();
+        }
         Struct::try_from(decl).ok()
     }
-}
 
-/* ─────────────────────────────── Conversions ────────────────────────────── */
-
-/// Generate [`Field`] from child-parent reference tuple, where the child is a [`EntityKind::FieldDecl`].
-impl<'a> TryFrom<(Entity<'a>, &Entity<'a>)> for Field<'a> {
-    type Error = FieldError;
-
-    fn try_from((entity, parent): (Entity<'a>, &Entity<'a>)) -> Result<Self, Self::Error> {
-        let kind = entity.get_kind();
-        if kind != EntityKind::FieldDecl {
-            return Err(FieldError::NotField(kind));
+    /// Collect the child fields of this field's underlying record
+    /// declaration, with anon-context inherited from this field's
+    /// [`AnonRef`] when present. Used by the display layer for inline
+    /// tree expansion.
+    ///
+    /// Returns an empty `Vec` when the underlying type isn't a record.
+    #[must_use]
+    pub fn get_child_fields(&self) -> Vec<Self> {
+        let underlying = self.get_underlying_type();
+        let Some(decl) = underlying.get_declaration() else {
+            return Vec::new();
+        };
+        let is_record = matches!(
+            decl.get_kind(),
+            EntityKind::StructDecl | EntityKind::ClassDecl | EntityKind::UnionDecl
+        );
+        if !is_record {
+            return Vec::new();
         }
+        match self.anon_ref.as_ref() {
+            Some(aref) => collect_fields(&decl, &aref.enclosing_record, &aref.field_path),
+            None => {
+                let name = decl.get_name().unwrap_or_default();
+                collect_fields(&decl, &name, &[])
+            }
+        }
+    }
 
-        let type_ = entity.get_type().ok_or(FieldError::NoType)?;
-        let name = entity.get_name().ok_or(FieldError::NoName)?;
-        let semantic_parent = entity.get_semantic_parent().ok_or(FieldError::NoType)?;
-        let anonymous_type = type_.is_anonymous().unwrap_or(false);
-        let type_name = (!anonymous_type).then(|| type_.get_display_name());
-
-        let mut type_info = TypeInfo::from(type_);
-        type_info.suppress_underlying_if_matches(type_name.as_deref());
-
-        let parent_type = parent.get_type().ok_or(FieldError::NoType)?;
-        let offset = parent_type
-            .get_offsetof(&name)
-            .map_err(|_| FieldError::NoOffset(name.clone()))?;
-        let location = SourceLocation::try_from(&entity).ok();
-        let size = type_.get_sizeof().map_err(|_| FieldError::NoSize)?;
-        let alignment = type_.get_alignof().map_err(|_| FieldError::NoAlignment)?;
-
-        Ok(Self {
-            entity,
-            semantic_parent,
-            name,
-            type_name,
-            type_info,
-            location,
-            offset,
-            offset_bytes: offset / 8,
-            size,
-            alignment,
-        })
+    /// The union declaration this field's underlying type points at,
+    /// if any. Returns `None` for structs or non-record types — use
+    /// [`Self::get_child_struct`] for structs.
+    #[must_use]
+    pub fn get_child_union(&self) -> Option<Union<'a>> {
+        let underlying = self.get_underlying_type();
+        let decl = underlying.get_declaration()?;
+        if decl.get_kind() != EntityKind::UnionDecl {
+            return None;
+        }
+        if let Some(aref) = &self.anon_ref
+            && aref.kind == RecordKind::Union
+        {
+            return Union::from_anon(decl, aref.enclosing_record.clone(), aref.field_path.clone())
+                .ok();
+        }
+        Union::try_from(decl).ok()
     }
 }
 
 /* ──────────────────────────────── Utilities ─────────────────────────────── */
 
-/// Collects all field declarations from a struct/class entity.
-pub fn collect_fields<'a>(entity: &Entity<'a>) -> Vec<Field<'a>> {
-    use clang::EntityVisitResult;
-
+/// Collects all field declarations from a struct/class/union entity.
+///
+/// `enclosing_record` is the outermost named ancestor's display name —
+/// for top-level records, the record's own name; for nested anonymous
+/// records, the same name propagated through the walk. `parent_path`
+/// is the chain of field names from `enclosing_record` down to (but
+/// not including) `parent` — empty at the top level.
+///
+/// Nameless members are accepted: each one gets a synthetic name
+/// `<anonymous_N>`. Two independent per-parent counters are
+/// maintained — one for nameless `FieldDecl`s and one for sibling
+/// anon-record decls (`StructDecl`/`UnionDecl`/`ClassDecl` with no
+/// surrounding FieldDecl) — so an ordering shuffle in clang's child
+/// visit order can't perturb existing identities. Both counters
+/// reset per `collect_fields` call, which matches the per-parent
+/// scoping in the JSON `field_path` semantics.
+#[must_use]
+pub fn collect_fields<'a>(
+    parent: &Entity<'a>,
+    enclosing_record: &str,
+    parent_path: &[String],
+) -> Vec<Field<'a>> {
     let mut fields = Vec::new();
-    entity.visit_children(|child, _| {
-        if child.get_kind() == EntityKind::FieldDecl
-            && let Ok(field) = Field::try_from((child, entity))
-        {
-            fields.push(field);
+    let mut nameless_field_idx = 0_usize;
+    let mut sibling_decl_idx = 0_usize;
+    parent.visit_children(|child, _| {
+        match child.get_kind() {
+            EntityKind::FieldDecl => {
+                let (name, is_anonymous) = match child.get_name() {
+                    Some(n) => (n, false),
+                    None => {
+                        let n = format!("<anonymous_{nameless_field_idx}>");
+                        nameless_field_idx += 1;
+                        (n, true)
+                    }
+                };
+                if let Ok(field) = build_field(
+                    child,
+                    parent,
+                    name,
+                    is_anonymous,
+                    enclosing_record,
+                    parent_path,
+                ) {
+                    fields.push(field);
+                }
+            }
+            // Anonymous nested record decls appear as direct children
+            // of the parent (siblings of FieldDecl) — this is how
+            // clang models the C macro pattern
+            // `union { ... } DUMMYUNIONNAME;` where the field name
+            // expands to empty under default MSVC parsing. We
+            // synthesize a Field for these so they appear in the
+            // layout at the right offset with an `anon_ref` into the
+            // referenced_unions / referenced_structs slot.
+            EntityKind::StructDecl | EntityKind::ClassDecl | EntityKind::UnionDecl
+                if child.is_anonymous() =>
+            {
+                let name = format!("<anonymous_{sibling_decl_idx}>");
+                sibling_decl_idx += 1;
+                if let Ok(field) =
+                    build_anon_record_field(child, parent, name, enclosing_record, parent_path)
+                {
+                    fields.push(field);
+                }
+            }
+            _ => {}
         }
         EntityVisitResult::Continue
     });
     fields
+}
+
+/// Build a [`Field`] with caller-supplied name and anon context.
+///
+/// Replaces the prior `TryFrom<(Entity, &Entity)>` constructor —
+/// `collect_fields` is now the canonical entry point because it
+/// computes the synthetic-name counter and threads
+/// `enclosing_record` / `parent_path`. The function is `pub(crate)`
+/// because the only legitimate caller is the field-collection loop.
+pub(crate) fn build_field<'a>(
+    entity: Entity<'a>,
+    parent: &Entity<'a>,
+    name: String,
+    is_anonymous: bool,
+    enclosing_record: &str,
+    parent_path: &[String],
+) -> Result<Field<'a>, FieldError> {
+    let kind = entity.get_kind();
+    if kind != EntityKind::FieldDecl {
+        return Err(FieldError::NotField(kind));
+    }
+
+    let type_ = entity.get_type().ok_or(FieldError::NoType)?;
+    let semantic_parent = entity.get_semantic_parent().ok_or(FieldError::NoType)?;
+    let anonymous_type = type_.is_anonymous().unwrap_or(false);
+    let type_name = (!anonymous_type).then(|| type_.get_display_name());
+
+    let mut type_info = TypeInfo::from(type_);
+    type_info.suppress_underlying_if_matches(type_name.as_deref());
+
+    let parent_type = parent.get_type().ok_or(FieldError::NoType)?;
+    // Offset lookup needs a real C identifier — skip for nameless
+    // fields, which carry offset 0 by C semantics (anon members live
+    // at the parent's offset).
+    let offset = if is_anonymous {
+        0
+    } else {
+        parent_type
+            .get_offsetof(&name)
+            .map_err(|_| FieldError::NoOffset(name.clone()))?
+    };
+
+    let location = SourceLocation::try_from(&entity).ok();
+    let size = type_.get_sizeof().map_err(|_| FieldError::NoSize)?;
+    let alignment = type_.get_alignof().map_err(|_| FieldError::NoAlignment)?;
+
+    let anon_ref = compute_anon_ref(&type_, &name, enclosing_record, parent_path);
+
+    Ok(Field {
+        entity,
+        semantic_parent,
+        name,
+        type_name,
+        type_info,
+        is_anonymous,
+        anon_ref,
+        location,
+        offset,
+        offset_bytes: offset / 8,
+        size,
+        alignment,
+    })
+}
+
+/// Build a synthetic [`Field`] from an anonymous record decl that
+/// appears as a direct child of a struct/union (no enclosing
+/// FieldDecl). Used for the OVERLAPPED pattern where
+/// `DUMMYUNIONNAME` expands to empty and the union is reachable only
+/// as a sibling decl of the named fields.
+///
+/// The synthetic field's offset is recovered by asking the parent
+/// type for the offset of the first reachable named member of the
+/// anonymous record — under default MSVC parsing, anonymous members
+/// are accessible from the parent's namespace, so this offset is
+/// well-defined and exactly equals the anonymous record's own offset
+/// within the parent.
+fn build_anon_record_field<'a>(
+    anon_decl: Entity<'a>,
+    parent: &Entity<'a>,
+    name: String,
+    enclosing_record: &str,
+    parent_path: &[String],
+) -> Result<Field<'a>, FieldError> {
+    let kind = match anon_decl.get_kind() {
+        EntityKind::StructDecl | EntityKind::ClassDecl => RecordKind::Struct,
+        EntityKind::UnionDecl => RecordKind::Union,
+        // visit_children only calls us when one of those three matched.
+        other => return Err(FieldError::NotField(other)),
+    };
+
+    let anon_type = anon_decl.get_type().ok_or(FieldError::NoType)?;
+    let size = anon_type.get_sizeof().map_err(|_| FieldError::NoSize)?;
+    let alignment = anon_type
+        .get_alignof()
+        .map_err(|_| FieldError::NoAlignment)?;
+    let parent_type = parent.get_type().ok_or(FieldError::NoType)?;
+    // Under default MSVC parsing the anon record's members are
+    // reachable from the parent's namespace, so picking any of them
+    // and asking the parent's type for its offset gives the anon
+    // record's own offset. With `NONAMELESSUNION` defined (or any
+    // other parse config that hides the namespace hoisting), this
+    // fails — the synthetic field would have to land at the wrong
+    // offset, so we drop it instead of silently emitting 0.
+    let offset = anon_record_offset_in_parent(&parent_type, &anon_decl)
+        .ok_or_else(|| FieldError::NoOffset(name.clone()))?;
+    let location = SourceLocation::try_from(&anon_decl).ok();
+    let semantic_parent = anon_decl.get_semantic_parent().ok_or(FieldError::NoType)?;
+
+    let type_info = TypeInfo::from(anon_type);
+
+    let mut path = parent_path.to_vec();
+    path.push(name.clone());
+    let anon_ref = Some(AnonRef {
+        kind,
+        enclosing_record: enclosing_record.to_string(),
+        field_path: path,
+    });
+
+    Ok(Field {
+        entity: anon_decl,
+        semantic_parent,
+        name,
+        type_name: None,
+        type_info,
+        is_anonymous: true,
+        anon_ref,
+        location,
+        offset,
+        offset_bytes: offset / 8,
+        size,
+        alignment,
+    })
+}
+
+/// Walk the anonymous record's children for any reachable named
+/// member and use that member's offset in the parent as the anon
+/// record's own offset. Recurses through nested anonymous records
+/// (which is exactly the OVERLAPPED case — an anon union containing
+/// an anon struct whose `Offset` member is the first reachable
+/// named field).
+///
+/// Returns the offset in bits (libclang's `get_offsetof` unit) or
+/// `None` if no reachable named member exists.
+fn anon_record_offset_in_parent(
+    parent_type: &clang::Type<'_>,
+    anon_decl: &Entity<'_>,
+) -> Option<usize> {
+    for child in anon_decl.get_children() {
+        match child.get_kind() {
+            EntityKind::FieldDecl => {
+                if let Some(name) = child.get_name()
+                    && let Ok(off) = parent_type.get_offsetof(&name)
+                {
+                    return Some(off);
+                }
+            }
+            EntityKind::StructDecl | EntityKind::ClassDecl | EntityKind::UnionDecl
+                if child.is_anonymous() =>
+            {
+                if let Some(off) = anon_record_offset_in_parent(parent_type, &child) {
+                    return Some(off);
+                }
+            }
+            _ => {}
+        }
+    }
+    None
+}
+
+/// If the field's underlying declaration is an anonymous record, build
+/// the [`AnonRef`] that cross-references the matching entry in the
+/// enclosing struct's `referenced_structs` / `referenced_unions` slot.
+///
+/// Returns `None` for fields whose type is named (its target lives in
+/// the named lookup slot), a primitive, a function pointer, or an
+/// anonymous *pointer-to-record* (the pointee is at one remove and
+/// shouldn't be inlined).
+fn compute_anon_ref(
+    field_type: &Type<'_>,
+    field_name: &str,
+    enclosing_record: &str,
+    parent_path: &[String],
+) -> Option<AnonRef> {
+    let canonical = field_type.get_canonical_type();
+    // Only the *direct* declaration kind matters — we don't follow
+    // pointer/array layers, because an anon record reached via a
+    // pointer wouldn't be inlined anyway.
+    let decl = canonical.get_declaration()?;
+    if !decl.is_anonymous() {
+        return None;
+    }
+    let kind = match decl.get_kind() {
+        EntityKind::StructDecl | EntityKind::ClassDecl => RecordKind::Struct,
+        EntityKind::UnionDecl => RecordKind::Union,
+        _ => return None,
+    };
+    let mut path: Vec<String> = parent_path.to_vec();
+    path.push(field_name.to_string());
+    Some(AnonRef {
+        kind,
+        enclosing_record: enclosing_record.to_string(),
+        field_path: path,
+    })
 }

--- a/crates/bb-clang/src/struct_/mod.rs
+++ b/crates/bb-clang/src/struct_/mod.rs
@@ -20,6 +20,13 @@ pub struct Struct<'a> {
     #[serde(skip)]
     entity: Entity<'a>,
     name: String,
+    /// Typedef names that resolve to this struct (e.g. `["LARGE_INTEGER"]`
+    /// for `_LARGE_INTEGER`). Populated by callers that have a
+    /// [`TypedefIndex`](crate::TypedefIndex) — see
+    /// [`Struct::with_aliases`]. Empty when no typedef points here, or
+    /// when the caller didn't supply an index.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    aliases: Vec<String>,
     #[serde(skip_serializing_if = "std::ops::Not::not")]
     is_anonymous: bool,
     location: Option<SourceLocation>,
@@ -53,10 +60,41 @@ impl<'a> Struct<'a> {
         self.is_anonymous
     }
 
-    /// Renders this struct in a `WinDbg` `dt`-style format with Unicode box-drawing.
+    /// Typedef names that resolve to this struct.
+    ///
+    /// Empty unless the struct was constructed (or post-processed) with a
+    /// [`TypedefIndex`](crate::TypedefIndex) — see [`Self::with_aliases`].
     #[must_use]
-    pub fn display(&self, depth: usize, field_filter: Option<&str>) -> String {
-        display::render_struct(self, depth, field_filter)
+    pub fn get_aliases(&self) -> &[String] {
+        &self.aliases
+    }
+
+    /// Attach typedef alias names to this struct.
+    ///
+    /// `aliases` is typically obtained from
+    /// [`TypedefIndex::aliases_for`](crate::TypedefIndex::aliases_for)
+    /// using `self.get_name()` as the key. Consumed builder-style so call
+    /// sites stay concise.
+    #[must_use]
+    pub fn with_aliases(mut self, aliases: Vec<String>) -> Self {
+        self.aliases = aliases;
+        self
+    }
+
+    /// Renders this struct in a `WinDbg` `dt`-style format with Unicode box-drawing.
+    ///
+    /// `typedef_index`, when supplied, lets the renderer annotate typedef'd
+    /// field types with their canonical form (e.g. `HANDLE (void *)`,
+    /// `LARGE_INTEGER (_LARGE_INTEGER)`). Pass `None` for the legacy
+    /// non-annotated output.
+    #[must_use]
+    pub fn display(
+        &self,
+        depth: usize,
+        field_filter: Option<&str>,
+        typedef_index: Option<&crate::TypedefIndex>,
+    ) -> String {
+        display::render_struct(self, depth, field_filter, typedef_index)
     }
 
     /// Returns the names of expandable child types referenced by this struct's fields.
@@ -144,13 +182,23 @@ impl<'a> Struct<'a> {
 
 /* ─────────────────────────────── Conversions ────────────────────────────── */
 
-/// Generate [`Struct`] from entity that is either a [`EntityKind::ClassDecl`] or [`EntityKind::StructDecl`].
+/// Generate [`Struct`] from a record-like declaration entity.
+///
+/// Accepts [`EntityKind::ClassDecl`], [`EntityKind::StructDecl`], and
+/// [`EntityKind::UnionDecl`]. Unions are represented as a `Struct` with
+/// overlapping field offsets — the same model `WinDbg`'s `dt` uses — so
+/// callers don't need a separate union type to render or query them.
+/// Notable Windows examples: `LARGE_INTEGER`, `ULARGE_INTEGER`, and
+/// many `_FOO` definitions in winnt.h are unions.
 impl<'a> TryFrom<Entity<'a>> for Struct<'a> {
     type Error = StructError;
 
     fn try_from(entity: Entity<'a>) -> Result<Self, Self::Error> {
         let kind = entity.get_kind();
-        if !matches!(kind, EntityKind::ClassDecl | EntityKind::StructDecl) {
+        if !matches!(
+            kind,
+            EntityKind::ClassDecl | EntityKind::StructDecl | EntityKind::UnionDecl
+        ) {
             return Err(StructError::NotStructOrClass(kind));
         }
 
@@ -178,6 +226,7 @@ impl<'a> TryFrom<Entity<'a>> for Struct<'a> {
         Ok(Self {
             entity,
             name,
+            aliases: Vec::new(),
             is_anonymous,
             location,
             size,

--- a/crates/bb-clang/src/struct_/mod.rs
+++ b/crates/bb-clang/src/struct_/mod.rs
@@ -1,14 +1,16 @@
 //! Struct type representation.
 
-mod field;
+pub(crate) mod field;
 
 pub use field::Field;
-use field::collect_fields;
+pub(crate) use field::collect_fields;
 
 use crate::display;
 use crate::error::StructError;
 use crate::ext::{AnonymousType, DeclarationKind};
 use crate::location::SourceLocation;
+use crate::record::RecordKind;
+use crate::union_::Union;
 use clang::{Entity, EntityKind};
 use serde::Serialize;
 use std::collections::HashSet;
@@ -20,6 +22,10 @@ pub struct Struct<'a> {
     #[serde(skip)]
     entity: Entity<'a>,
     name: String,
+    /// Always [`RecordKind::Struct`]. Carried so the JSON shape is
+    /// symmetric with [`Union`] entries; consumers can dispatch on
+    /// `kind` without checking which array the entry came from.
+    kind: RecordKind,
     /// Typedef names that resolve to this struct (e.g. `["LARGE_INTEGER"]`
     /// for `_LARGE_INTEGER`). Populated by callers that have a
     /// [`TypedefIndex`](crate::TypedefIndex) — see
@@ -29,6 +35,15 @@ pub struct Struct<'a> {
     aliases: Vec<String>,
     #[serde(skip_serializing_if = "std::ops::Not::not")]
     is_anonymous: bool,
+    /// Outermost named ancestor's display name. `Some` only for
+    /// anonymous nested structs surfaced in a parent's
+    /// `referenced_structs` slot.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    enclosing_record: Option<String>,
+    /// Field-name chain from `enclosing_record` down to this record.
+    /// Empty for top-level / named structs.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    field_path: Vec<String>,
     location: Option<SourceLocation>,
     size: Option<usize>,
     fields: Vec<Field<'a>>,
@@ -59,34 +74,49 @@ impl<'a> Struct<'a> {
     pub const fn is_anonymous(&self) -> bool {
         self.is_anonymous
     }
+    #[must_use]
+    pub const fn kind(&self) -> RecordKind {
+        self.kind
+    }
+    #[must_use]
+    pub fn get_enclosing_record(&self) -> Option<&str> {
+        self.enclosing_record.as_deref()
+    }
+    #[must_use]
+    pub fn get_field_path(&self) -> &[String] {
+        &self.field_path
+    }
 
     /// Typedef names that resolve to this struct.
-    ///
-    /// Empty unless the struct was constructed (or post-processed) with a
-    /// [`TypedefIndex`](crate::TypedefIndex) — see [`Self::with_aliases`].
     #[must_use]
     pub fn get_aliases(&self) -> &[String] {
         &self.aliases
     }
 
     /// Attach typedef alias names to this struct.
-    ///
-    /// `aliases` is typically obtained from
-    /// [`TypedefIndex::aliases_for`](crate::TypedefIndex::aliases_for)
-    /// using `self.get_name()` as the key. Consumed builder-style so call
-    /// sites stay concise.
     #[must_use]
     pub fn with_aliases(mut self, aliases: Vec<String>) -> Self {
         self.aliases = aliases;
         self
     }
 
+    /// Stable identity for dedup across a flat nested-record list. For
+    /// named structs, returns the canonical name. For anonymous ones,
+    /// returns `"enclosing_record::field_path"`.
+    #[must_use]
+    pub fn identity(&self) -> String {
+        if self.is_anonymous {
+            format!(
+                "{}::{}",
+                self.enclosing_record.as_deref().unwrap_or(""),
+                self.field_path.join("::")
+            )
+        } else {
+            self.name.clone()
+        }
+    }
+
     /// Renders this struct in a `WinDbg` `dt`-style format with Unicode box-drawing.
-    ///
-    /// `typedef_index`, when supplied, lets the renderer annotate typedef'd
-    /// field types with their canonical form (e.g. `HANDLE (void *)`,
-    /// `LARGE_INTEGER (_LARGE_INTEGER)`). Pass `None` for the legacy
-    /// non-annotated output.
     #[must_use]
     pub fn display(
         &self,
@@ -97,114 +127,57 @@ impl<'a> Struct<'a> {
         display::render_struct(self, depth, field_filter, typedef_index)
     }
 
-    /// Returns the names of expandable child types referenced by this struct's fields.
-    ///
-    /// Skips anonymous types (they have no meaningful name to look up).
-    /// Each name appears at most once, in field order.
+    /// Names of *named* record types (struct or union) referenced by
+    /// this struct's fields. Anonymous nested records are omitted here
+    /// because they have no string name — they're only visible in the
+    /// full `to_json_full` dump where `(enclosing_record, field_path)`
+    /// disambiguates them.
     #[must_use]
     pub fn referenced_type_names(&self) -> Vec<String> {
-        let mut names = Vec::new();
-        let mut seen = HashSet::new();
-        for field in &self.fields {
-            if !field.has_children() {
-                continue;
-            }
-            let Some(decl) = field.get_underlying_type().get_declaration() else {
-                continue;
-            };
-            let is_anonymous = decl
-                .get_type()
-                .and_then(|t| t.is_anonymous())
-                .unwrap_or(false);
-            if is_anonymous {
-                continue;
-            }
-            if let Some(name) = decl.get_name()
-                && seen.insert(name.clone())
-            {
-                names.push(name);
-            }
-        }
-        names
+        referenced_named_record_names(&self.fields)
     }
 
-    /// Extracts all nested struct types up to the specified depth for JSON serialization.
-    ///
-    /// Unlike `display()`, this collects unique nested types into a flat list rather than
-    /// rendering them inline. Each nested type appears only once in the result, regardless
-    /// of how many fields reference it.
-    ///
-    /// # Cycle Detection
-    ///
-    /// Uses a [`HashSet<String>`] to track already-collected type names. Unlike `display()`,
-    /// we do NOT remove names after processing because we want global deduplication
-    /// (each type should appear exactly once in the output array).
+    /// All nested record types — structs and unions, named and
+    /// anonymous — referenced from this struct's field tree, up to
+    /// `max_depth` levels of recursion. Returns `(structs, unions)`
+    /// for the two JSON slots. Deduplicated by [`Self::identity`] /
+    /// [`Union::identity`].
     #[must_use]
-    pub fn extract_nested_types(&self, depth: usize) -> Vec<Self> {
-        let mut result = Vec::new();
-        let mut seen = HashSet::new();
-        seen.insert(self.name.clone());
-        self.collect_nested(&mut result, &mut seen, depth, 0);
-        result
-    }
-
-    /// Recursively collects nested struct types from fields.
-    ///
-    /// # Arguments
-    ///
-    /// * `result` - Accumulator for collected structs.
-    /// * `seen` - Set of type names already processed (for global deduplication).
-    /// * `max_depth` - Maximum recursion depth.
-    /// * `current_depth` - Current recursion level.
-    fn collect_nested(
-        &self,
-        result: &mut Vec<Self>,
-        seen: &mut HashSet<String>,
-        max_depth: usize,
-        current_depth: usize,
-    ) {
-        if current_depth >= max_depth {
-            return;
-        }
-
-        for field in &self.fields {
-            if let Some(child_struct) = field.get_child_struct() {
-                // Only process types we haven't seen before (global deduplication)
-                if seen.insert(child_struct.name.clone()) {
-                    // Recurse first to collect deeper types
-                    child_struct.collect_nested(result, seen, max_depth, current_depth + 1);
-                    result.push(child_struct);
-                }
-            }
-        }
+    pub fn extract_nested_records(&self, max_depth: usize) -> (Vec<Self>, Vec<Union<'a>>) {
+        let mut structs: Vec<Self> = Vec::new();
+        let mut unions: Vec<Union<'a>> = Vec::new();
+        let mut seen: HashSet<String> = HashSet::new();
+        seen.insert(self.identity());
+        collect_nested_from_fields(
+            &self.fields,
+            &mut structs,
+            &mut unions,
+            &mut seen,
+            max_depth,
+            0,
+        );
+        (structs, unions)
     }
 }
 
 /* ─────────────────────────────── Conversions ────────────────────────────── */
 
-/// Generate [`Struct`] from a record-like declaration entity.
+/// Generate [`Struct`] from a `struct`/`class` declaration entity.
 ///
-/// Accepts [`EntityKind::ClassDecl`], [`EntityKind::StructDecl`], and
-/// [`EntityKind::UnionDecl`]. Unions are represented as a `Struct` with
-/// overlapping field offsets — the same model `WinDbg`'s `dt` uses — so
-/// callers don't need a separate union type to render or query them.
-/// Notable Windows examples: `LARGE_INTEGER`, `ULARGE_INTEGER`, and
-/// many `_FOO` definitions in winnt.h are unions.
+/// Rejects [`EntityKind::UnionDecl`] — unions go through [`Union::try_from`]
+/// and are never returned as a struct. This is the change that makes
+/// unions un-findable as top-level types via `bb-types -s ...`.
 impl<'a> TryFrom<Entity<'a>> for Struct<'a> {
     type Error = StructError;
 
     fn try_from(entity: Entity<'a>) -> Result<Self, Self::Error> {
         let kind = entity.get_kind();
-        if !matches!(
-            kind,
-            EntityKind::ClassDecl | EntityKind::StructDecl | EntityKind::UnionDecl
-        ) {
+        if !matches!(kind, EntityKind::ClassDecl | EntityKind::StructDecl) {
             return Err(StructError::NotStructOrClass(kind));
         }
 
         let location = SourceLocation::try_from(&entity).ok();
 
-        // Handle anonymous structures
         let is_anonymous = entity
             .get_type()
             .and_then(|t| t.is_anonymous())
@@ -214,23 +187,156 @@ impl<'a> TryFrom<Entity<'a>> for Struct<'a> {
             let kind_str = entity
                 .get_type()
                 .and_then(|t| t.get_declaration_kind_name())
-                .unwrap_or("type");
+                .unwrap_or("struct");
             format!("<anonymous {kind_str}>")
         } else {
             entity.get_name().ok_or(StructError::NoName)?
         };
 
-        let fields = collect_fields(&entity);
+        let fields = collect_fields(&entity, &name, &[]);
         let size = entity.get_type().and_then(|t| t.get_sizeof().ok());
 
         Ok(Self {
             entity,
             name,
+            kind: RecordKind::Struct,
             aliases: Vec::new(),
             is_anonymous,
+            enclosing_record: None,
+            field_path: Vec::new(),
             location,
             size,
             fields,
         })
+    }
+}
+
+impl<'a> Struct<'a> {
+    /// Build a [`Struct`] for an anonymous nested record, carrying the
+    /// caller-supplied identity context. Used by [`Field::get_child_struct`]
+    /// when the field's `anon_ref` indicates an anonymous struct.
+    pub(crate) fn from_anon(
+        entity: Entity<'a>,
+        enclosing_record: String,
+        field_path: Vec<String>,
+    ) -> Result<Self, StructError> {
+        let kind = entity.get_kind();
+        if !matches!(kind, EntityKind::ClassDecl | EntityKind::StructDecl) {
+            return Err(StructError::NotStructOrClass(kind));
+        }
+        let location = SourceLocation::try_from(&entity).ok();
+        // Synthetic name = the field name that points at this record,
+        // i.e. the last element of the path. Stable per snapshot.
+        let name = field_path
+            .last()
+            .cloned()
+            .unwrap_or_else(|| "<anonymous>".to_string());
+        let fields = collect_fields(&entity, &enclosing_record, &field_path);
+        let size = entity.get_type().and_then(|t| t.get_sizeof().ok());
+        Ok(Self {
+            entity,
+            name,
+            kind: RecordKind::Struct,
+            aliases: Vec::new(),
+            is_anonymous: true,
+            enclosing_record: Some(enclosing_record),
+            field_path,
+            location,
+            size,
+            fields,
+        })
+    }
+}
+
+/* ───────────────────────────── Nested traversal ─────────────────────────── */
+
+/// Collect names of every *named* record (struct or union) referenced
+/// by `fields`. Anonymous nested records are intentionally excluded —
+/// they live in the full-record extraction path instead, keyed by
+/// `(enclosing_record, field_path)`.
+pub(crate) fn referenced_named_record_names(fields: &[Field]) -> Vec<String> {
+    let mut names = Vec::new();
+    let mut seen: HashSet<String> = HashSet::new();
+    for field in fields {
+        // anon_ref means anonymous target — skip for the name list.
+        if field.get_anon_ref().is_some() {
+            continue;
+        }
+        if !field.has_children() {
+            continue;
+        }
+        let Some(decl) = field.get_underlying_type().get_declaration() else {
+            continue;
+        };
+        if !matches!(
+            decl.get_kind(),
+            EntityKind::StructDecl | EntityKind::ClassDecl | EntityKind::UnionDecl
+        ) {
+            continue;
+        }
+        if let Some(name) = decl.get_name()
+            && seen.insert(name.clone())
+        {
+            names.push(name);
+        }
+    }
+    names
+}
+
+/// Walk `fields`, accumulating every reachable struct and union (named
+/// or anonymous) into `structs` / `unions`. Cycles are broken by the
+/// composite-identity `seen` set.
+pub(crate) fn collect_nested_from_fields<'a>(
+    fields: &[Field<'a>],
+    structs: &mut Vec<Struct<'a>>,
+    unions: &mut Vec<Union<'a>>,
+    seen: &mut HashSet<String>,
+    max_depth: usize,
+    current_depth: usize,
+) {
+    if current_depth >= max_depth {
+        return;
+    }
+    for field in fields {
+        // Dispatch on the field's underlying record kind directly so
+        // a future change to `get_child_struct` / `get_child_union`
+        // can't silently change which arm fires.
+        match field.record_kind() {
+            Some(RecordKind::Struct) => {
+                let Some(child_struct) = field.get_child_struct() else {
+                    continue;
+                };
+                let id = child_struct.identity();
+                if seen.insert(id) {
+                    collect_nested_from_fields(
+                        child_struct.get_fields(),
+                        structs,
+                        unions,
+                        seen,
+                        max_depth,
+                        current_depth + 1,
+                    );
+                    structs.push(child_struct);
+                }
+            }
+            Some(RecordKind::Union) => {
+                let Some(child_union) = field.get_child_union() else {
+                    continue;
+                };
+                let id = child_union.identity();
+                if seen.insert(id) {
+                    collect_nested_from_fields(
+                        child_union.get_fields(),
+                        structs,
+                        unions,
+                        seen,
+                        max_depth,
+                        current_depth + 1,
+                    );
+                    unions.push(child_union);
+                }
+            }
+            None => {}
+        }
     }
 }

--- a/crates/bb-clang/src/type_info.rs
+++ b/crates/bb-clang/src/type_info.rs
@@ -1,36 +1,41 @@
 //! Shared type metadata extracted from a [`clang::Type`].
 //!
 //! [`TypeInfo`] is the single source of truth for type classification
-//! (pointer, array, const, underlying type) used by both [`Field`](crate::Field)
-//! and [`Param`](crate::Param).
+//! (pointer, array, const, terminal primitive, underlying record) used by
+//! [`Field`](crate::Field), [`Param`](crate::Param), and
+//! [`Typedef`](crate::Typedef). The data-only subset is exposed as
+//! [`TypeProperties`], which can be embedded and serialized into any
+//! type-shaped JSON object via `#[serde(flatten)]` — that's how all three
+//! parent types stay shape-compatible for API consumers.
 
 use clang::{Type, TypeKind};
 use serde::Serialize;
 
 use crate::ext::UnderlyingType;
 
-/* ────────────────────────────────── Type ────────────────────────────────── */
+/* ────────────────────────────────── Types ───────────────────────────────── */
 
-/// Extracted type metadata from a [`clang::Type`].
+/// Serializable type metadata. Carries the same information for any type
+/// in any context — fields, params, typedefs — so API consumers always
+/// see the same shape.
 ///
-/// Holds both the raw clang type (for further introspection) and the
-/// serializable properties that describe the type's nature.
-#[derive(Debug, Serialize)]
+/// All boolean flags describe the type *with qualifiers and pointers*,
+/// not the canonical leaf. `underlying_type` is the **terminal primitive**
+/// at the bottom of the canonical chain (e.g. `void`, `int`, `char`).
+/// `underlying_record` is the **record/enum declaration name** after
+/// stripping one level of pointer/array indirection (e.g. for
+/// `LIST_ENTRY *`, this is `_LIST_ENTRY`). The two are mutually exclusive
+/// in practice: pointer/primitive typedefs set the former, record
+/// typedefs the latter.
+#[derive(Debug, Clone, Default, Serialize)]
 #[allow(clippy::struct_excessive_bools)] // Each bool represents a distinct type property.
-pub struct TypeInfo<'a> {
-    /// The raw clang type. Available for further introspection but
-    /// skipped during serialization.
-    #[serde(skip)]
-    type_: Type<'a>,
-    /// The resolved underlying type name after stripping pointers and arrays.
-    /// Only present when it differs from the display name.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub underlying_type: Option<String>,
+pub struct TypeProperties {
     pub is_const: bool,
     pub is_volatile: bool,
     pub is_restrict: bool,
     pub is_pointer: bool,
-    /// How many levels of pointer indirection (e.g. `PVOID**` = 2, `HANDLE` = 1 if ptr typedef, plain `DWORD` = 0).
+    /// How many levels of pointer indirection (e.g. `PVOID**` = 2,
+    /// `HANDLE` = 1, plain `DWORD` = 0).
     #[serde(skip_serializing_if = "is_zero")]
     pub pointer_depth: usize,
     pub is_function_pointer: bool,
@@ -38,19 +43,104 @@ pub struct TypeInfo<'a> {
     /// The number of elements in a fixed-size array, if applicable.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub array_size: Option<usize>,
+    /// Terminal primitive at the bottom of the canonical chain.
+    /// e.g. `void`, `int`, `char`, `unsigned long`, `bool`. `None` when
+    /// the chain bottoms at a record (struct/union/enum) — consult
+    /// `underlying_record` for that case.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub underlying_type: Option<String>,
+    /// Record/enum declaration name after stripping one level of pointer
+    /// or array indirection. e.g. for `LIST_ENTRY *`, this is
+    /// `_LIST_ENTRY`. `None` when there's no named record at the bottom
+    /// of the chain (the type bottoms at a primitive or anonymous).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub underlying_record: Option<String>,
+}
+
+impl TypeProperties {
+    /// Compute properties from a clang [`Type`].
+    ///
+    /// Walks the canonical form to determine pointer/array/function-pointer
+    /// classification, then walks **all** the way down (through every
+    /// pointer/array layer) to find the terminal primitive when there is
+    /// one. The first-step pointee is consulted separately for the
+    /// `underlying_record` field.
+    #[must_use]
+    pub fn from_type(type_: &Type<'_>) -> Self {
+        let canonical = type_.get_canonical_type();
+        let is_const = type_.is_const_qualified();
+        let is_volatile = type_.is_volatile_qualified();
+        let is_restrict = type_.is_restrict_qualified();
+        let is_pointer = canonical.get_pointee_type().is_some();
+        let pointer_depth = count_pointer_depth(&canonical);
+        let is_function_pointer = is_func_ptr(&canonical);
+        let is_array = matches!(
+            canonical.get_kind(),
+            TypeKind::ConstantArray | TypeKind::IncompleteArray | TypeKind::VariableArray
+        );
+        let array_size = if is_array { canonical.get_size() } else { None };
+
+        // Old semantics — useful for "what struct does this pointer
+        // ultimately point at?". Strip one level of pointer/array.
+        let after_one_strip = type_.get_underlying_type();
+        let underlying_record = after_one_strip.get_declaration().and_then(|d| d.get_name());
+
+        // Walk all the way to the terminal scalar leaf. Returns None when
+        // the chain bottoms at a record (or anonymous / unhandled kind).
+        let underlying_type = terminal_primitive_name(&canonical);
+
+        Self {
+            is_const,
+            is_volatile,
+            is_restrict,
+            is_pointer,
+            pointer_depth,
+            is_function_pointer,
+            is_array,
+            array_size,
+            underlying_type,
+            underlying_record,
+        }
+    }
+
+    /// Clear `underlying_record` if it matches the given display name.
+    ///
+    /// Used by [`Field`](crate::Field) and [`Param`](crate::Param) to
+    /// avoid redundant output when the rendered type name already says
+    /// `_LIST_ENTRY` and the record name would just repeat that.
+    pub fn suppress_underlying_record_if_matches(&mut self, display_name: Option<&str>) {
+        if let Some(ref r) = self.underlying_record
+            && display_name.is_some_and(|d| d == r)
+        {
+            self.underlying_record = None;
+        }
+    }
+}
+
+/// Extracted type metadata from a [`clang::Type`], with the raw type
+/// preserved for further introspection.
+///
+/// Embeds [`TypeProperties`] via `#[serde(flatten)]` so the serialized
+/// shape is identical to that of [`Typedef`](crate::Typedef). Field /
+/// Param consumers and Typedef consumers see the same metadata vocabulary.
+#[derive(Debug, Serialize)]
+pub struct TypeInfo<'a> {
+    /// The raw clang type. Available for further introspection but
+    /// skipped during serialization.
+    #[serde(skip)]
+    type_: Type<'a>,
+    #[serde(flatten)]
+    pub properties: TypeProperties,
 }
 
 impl<'a> TypeInfo<'a> {
-    /// Clear `underlying_type` if it matches the given display name.
+    /// Clear `underlying_record` if it matches the given display name.
     ///
-    /// Used by [`Field`](crate::Field) and [`Param`](crate::Param) to avoid
-    /// redundant output when the underlying type is the same as the display type.
+    /// Delegates to [`TypeProperties::suppress_underlying_record_if_matches`].
+    /// Kept on `TypeInfo` for source-compatibility with prior callers.
     pub fn suppress_underlying_if_matches(&mut self, display_name: Option<&str>) {
-        if let Some(ref u) = self.underlying_type
-            && display_name.is_some_and(|d| d == u)
-        {
-            self.underlying_type = None;
-        }
+        self.properties
+            .suppress_underlying_record_if_matches(display_name);
     }
 
     /// The raw clang type.
@@ -72,43 +162,19 @@ impl<'a> TypeInfo<'a> {
     }
 }
 
+impl<'a> std::ops::Deref for TypeInfo<'a> {
+    type Target = TypeProperties;
+    fn deref(&self) -> &TypeProperties {
+        &self.properties
+    }
+}
+
 /* ─────────────────────────────── Conversions ────────────────────────────── */
 
 impl<'a> From<Type<'a>> for TypeInfo<'a> {
-    /// Extract type metadata from a clang type.
-    ///
-    /// The `underlying_type` field is always populated when a declaration
-    /// name is available. Use [`suppress_underlying_if_matches`](Self::suppress_underlying_if_matches)
-    /// to clear it when it matches the display name.
     fn from(type_: Type<'a>) -> Self {
-        let canonical = type_.get_canonical_type();
-        let is_const = type_.is_const_qualified();
-        let is_volatile = type_.is_volatile_qualified();
-        let is_restrict = type_.is_restrict_qualified();
-        let is_pointer = canonical.get_pointee_type().is_some();
-        let pointer_depth = count_pointer_depth(&canonical);
-        let is_function_pointer = is_func_ptr(&canonical);
-        let is_array = matches!(
-            canonical.get_kind(),
-            TypeKind::ConstantArray | TypeKind::IncompleteArray | TypeKind::VariableArray
-        );
-        let array_size = if is_array { canonical.get_size() } else { None };
-
-        let underlying = type_.get_underlying_type();
-        let underlying_type = underlying.get_declaration().and_then(|d| d.get_name());
-
-        Self {
-            type_,
-            underlying_type,
-            is_const,
-            is_volatile,
-            is_restrict,
-            is_pointer,
-            pointer_depth,
-            is_function_pointer,
-            is_array,
-            array_size,
-        }
+        let properties = TypeProperties::from_type(&type_);
+        Self { type_, properties }
     }
 }
 
@@ -138,6 +204,67 @@ fn is_func_ptr(canonical: &Type) -> bool {
             TypeKind::FunctionPrototype | TypeKind::FunctionNoPrototype
         )
     })
+}
+
+/// Walk every pointer / array / typedef layer and return the canonical
+/// display name of the terminal scalar if the leaf is a builtin.
+///
+/// Returns `None` when the leaf is a record/enum (use `underlying_record`
+/// instead) or a function type (use `is_function_pointer`).
+fn terminal_primitive_name(canonical: &Type<'_>) -> Option<String> {
+    let mut current = canonical.get_canonical_type();
+    let mut guard = 0_usize;
+    loop {
+        if let Some(pointee) = current.get_pointee_type() {
+            current = pointee.get_canonical_type();
+        } else if let Some(element) = current.get_element_type() {
+            current = element.get_canonical_type();
+        } else {
+            break;
+        }
+        guard += 1;
+        if guard > 64 {
+            return None;
+        }
+    }
+    if is_primitive_kind(current.get_kind()) {
+        Some(current.get_display_name())
+    } else {
+        None
+    }
+}
+
+/// Whether a [`TypeKind`] is a builtin scalar (suitable for the
+/// `underlying_type` primitive slot).
+const fn is_primitive_kind(k: TypeKind) -> bool {
+    matches!(
+        k,
+        TypeKind::Void
+            | TypeKind::Bool
+            | TypeKind::CharS
+            | TypeKind::CharU
+            | TypeKind::SChar
+            | TypeKind::UChar
+            | TypeKind::WChar
+            | TypeKind::Char16
+            | TypeKind::Char32
+            | TypeKind::Short
+            | TypeKind::UShort
+            | TypeKind::Int
+            | TypeKind::UInt
+            | TypeKind::Long
+            | TypeKind::ULong
+            | TypeKind::LongLong
+            | TypeKind::ULongLong
+            | TypeKind::Int128
+            | TypeKind::UInt128
+            | TypeKind::Half
+            | TypeKind::Float
+            | TypeKind::Double
+            | TypeKind::LongDouble
+            | TypeKind::Float128
+            | TypeKind::Nullptr
+    )
 }
 
 /// Serde helper: skip serializing when value is zero.

--- a/crates/bb-clang/src/type_info.rs
+++ b/crates/bb-clang/src/type_info.rs
@@ -308,4 +308,3 @@ pub(crate) const fn is_array_kind(k: TypeKind) -> bool {
 pub(crate) fn is_function_pointer(ty: &Type<'_>) -> bool {
     is_func_ptr(&ty.get_canonical_type())
 }
-

--- a/crates/bb-clang/src/type_info.rs
+++ b/crates/bb-clang/src/type_info.rs
@@ -74,10 +74,7 @@ impl TypeProperties {
         let is_pointer = canonical.get_pointee_type().is_some();
         let pointer_depth = count_pointer_depth(&canonical);
         let is_function_pointer = is_func_ptr(&canonical);
-        let is_array = matches!(
-            canonical.get_kind(),
-            TypeKind::ConstantArray | TypeKind::IncompleteArray | TypeKind::VariableArray
-        );
+        let is_array = is_array_kind(canonical.get_kind());
         let array_size = if is_array { canonical.get_size() } else { None };
 
         // Old semantics — useful for "what struct does this pointer
@@ -234,9 +231,17 @@ fn terminal_primitive_name(canonical: &Type<'_>) -> Option<String> {
     }
 }
 
-/// Whether a [`TypeKind`] is a builtin scalar (suitable for the
-/// `underlying_type` primitive slot).
-const fn is_primitive_kind(k: TypeKind) -> bool {
+/// Whether a [`TypeKind`] is a builtin scalar — single source of truth
+/// for "what counts as a primitive" across the crate.
+///
+/// Used by `TypeProperties::from_type` to decide whether the terminal
+/// leaf of a canonical chain qualifies for the `underlying_type` slot,
+/// and by [`crate::typedef::TypedefIndex`] to classify a typedef whose
+/// canonical type is one of these. Centralising it here means future
+/// additions (new clang `TypeKind`s, exotic scalars) only need to
+/// change one place.
+#[must_use]
+pub(crate) const fn is_primitive_kind(k: TypeKind) -> bool {
     matches!(
         k,
         TypeKind::Void
@@ -265,6 +270,26 @@ const fn is_primitive_kind(k: TypeKind) -> bool {
             | TypeKind::Float128
             | TypeKind::Nullptr
     )
+}
+
+/// Whether a [`TypeKind`] is one of the three array flavors clang
+/// surfaces. Same centralisation rationale as [`is_primitive_kind`].
+#[must_use]
+pub(crate) const fn is_array_kind(k: TypeKind) -> bool {
+    matches!(
+        k,
+        TypeKind::ConstantArray | TypeKind::IncompleteArray | TypeKind::VariableArray
+    )
+}
+
+/// Whether a [`Type`] is a function pointer (pointer-to-function).
+///
+/// Walks one pointee level — `int (*)(...)` is a pointer; the pointee
+/// is the function prototype itself. Exposed at crate scope so the
+/// typedef classifier can call it without re-implementing the dance.
+#[must_use]
+pub(crate) fn is_function_pointer(ty: &Type<'_>) -> bool {
+    is_func_ptr(&ty.get_canonical_type())
 }
 
 /// Serde helper: skip serializing when value is zero.

--- a/crates/bb-clang/src/type_info.rs
+++ b/crates/bb-clang/src/type_info.rs
@@ -35,8 +35,9 @@ pub struct TypeProperties {
     pub is_restrict: bool,
     pub is_pointer: bool,
     /// How many levels of pointer indirection (e.g. `PVOID**` = 2,
-    /// `HANDLE` = 1, plain `DWORD` = 0).
-    #[serde(skip_serializing_if = "is_zero")]
+    /// `HANDLE` = 1, plain `DWORD` = 0). Always emitted in JSON so
+    /// consumers can pair it with `is_pointer` without an
+    /// "absent = 0" special case.
     pub pointer_depth: usize,
     pub is_function_pointer: bool,
     pub is_array: bool,
@@ -100,16 +101,23 @@ impl TypeProperties {
         }
     }
 
-    /// Clear `underlying_record` if it matches the given display name.
+    /// Clear `underlying_record` and `underlying_type` if either matches
+    /// the given display name.
     ///
     /// Used by [`Field`](crate::Field) and [`Param`](crate::Param) to
     /// avoid redundant output when the rendered type name already says
-    /// `_LIST_ENTRY` and the record name would just repeat that.
+    /// `_LIST_ENTRY` and the record name would just repeat it, or when
+    /// the displayed type is itself the terminal primitive (e.g. a
+    /// plain `int` field shouldn't also emit `"underlying_type": "int"`
+    /// in JSON).
     pub fn suppress_underlying_record_if_matches(&mut self, display_name: Option<&str>) {
-        if let Some(ref r) = self.underlying_record
-            && display_name.is_some_and(|d| d == r)
-        {
-            self.underlying_record = None;
+        if let Some(d) = display_name {
+            if self.underlying_record.as_deref() == Some(d) {
+                self.underlying_record = None;
+            }
+            if self.underlying_type.as_deref() == Some(d) {
+                self.underlying_type = None;
+            }
         }
     }
 }
@@ -209,8 +217,13 @@ fn is_func_ptr(canonical: &Type) -> bool {
 /// Returns `None` when the leaf is a record/enum (use `underlying_record`
 /// instead) or a function type (use `is_function_pointer`).
 fn terminal_primitive_name(canonical: &Type<'_>) -> Option<String> {
+    // Cap detects runaway recursion on malformed types. Real chains
+    // are very shallow (≤ ~3 pointer/array layers); 64 is generous.
+    // Truncation emits an `eprintln!` so it doesn't silently produce
+    // wrong metadata.
+    const MAX_DEPTH: usize = 64;
     let mut current = canonical.get_canonical_type();
-    let mut guard = 0_usize;
+    let mut depth = 0_usize;
     loop {
         if let Some(pointee) = current.get_pointee_type() {
             current = pointee.get_canonical_type();
@@ -219,8 +232,12 @@ fn terminal_primitive_name(canonical: &Type<'_>) -> Option<String> {
         } else {
             break;
         }
-        guard += 1;
-        if guard > 64 {
+        depth += 1;
+        if depth >= MAX_DEPTH {
+            eprintln!(
+                "bb-clang: terminal_primitive_name walked {MAX_DEPTH}+ pointer/array \
+                 layers without bottoming out — abandoning"
+            );
             return None;
         }
     }
@@ -292,8 +309,3 @@ pub(crate) fn is_function_pointer(ty: &Type<'_>) -> bool {
     is_func_ptr(&ty.get_canonical_type())
 }
 
-/// Serde helper: skip serializing when value is zero.
-#[allow(clippy::trivially_copy_pass_by_ref)] // Required by serde skip_serializing_if signature.
-const fn is_zero(v: &usize) -> bool {
-    *v == 0
-}

--- a/crates/bb-clang/src/typedef.rs
+++ b/crates/bb-clang/src/typedef.rs
@@ -1,0 +1,374 @@
+//! Typedef index for resolving alias names to their canonical types.
+//!
+//! Windows headers expose most struct types under both an underscored
+//! declaration name (e.g. `_LARGE_INTEGER`) and a typedef alias
+//! (e.g. `LARGE_INTEGER`). Pointer typedefs like `HANDLE` and `PVOID`
+//! never declare a struct — they alias `void *`.
+//!
+//! [`TypedefIndex::build`] walks a [`TranslationUnit`] once, collecting
+//! every [`EntityKind::TypedefDecl`] into a name-keyed map. Each entry
+//! records:
+//!
+//! - the immediate next link in the typedef chain (`typedef_of`),
+//! - the fully resolved canonical display (`canonical`),
+//! - the kind of the final type ([`TypedefKind`]),
+//! - the full step-by-step chain.
+//!
+//! Consumers can then ask:
+//!
+//! - "Does this name resolve to a struct, and if so what's its canonical
+//!   decl name?" — used by `bb-types` to make `LARGE_INTEGER` searches hit
+//!   the `_LARGE_INTEGER` struct.
+//! - "What are all the typedef aliases for a given canonical decl?" — used
+//!   to attach `aliases` to [`Struct`](crate::Struct) for display + JSON.
+//! - "What does this typedef expand to?" — used by the field/param
+//!   renderers to annotate `HANDLE (void *)`, `PVOID (void *)`, etc.
+
+use std::collections::HashMap;
+
+use clang::{Entity, EntityKind, TranslationUnit, Type, TypeKind};
+use serde::Serialize;
+
+use crate::ext::AnonymousType;
+use crate::location::SourceLocation;
+
+/* ────────────────────────────────── Types ───────────────────────────────── */
+
+/// Classification of what a typedef ultimately resolves to.
+///
+/// Determined by inspecting the canonical type after walking through every
+/// intermediate typedef link.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TypedefKind {
+    /// Canonical type is a `struct` or `class` declaration.
+    Struct,
+    /// Canonical type is a `union` declaration.
+    Union,
+    /// Canonical type is an `enum` declaration.
+    Enum,
+    /// Canonical type is a function pointer.
+    FunctionPointer,
+    /// Canonical type is a pointer (other than function pointer) — e.g. `void *`, `struct *`.
+    Pointer,
+    /// Canonical type is a fixed-size or incomplete array.
+    Array,
+    /// Canonical type is a builtin scalar (int, void, char, ...).
+    Primitive,
+    /// Anything else we don't classify (templates, dependent types, ...).
+    Other,
+}
+
+/// A single typedef entry: name + chain + canonical resolution + classification.
+///
+/// Serializes to a flat JSON object suitable for inclusion in the
+/// `typedefs` array of `bb-types` output. All names use the human-readable
+/// form (matches `Type::get_display_name`).
+#[derive(Debug, Clone, Serialize)]
+pub struct Typedef {
+    /// Typedef name as declared (e.g. `"LARGE_INTEGER"`, `"HANDLE"`).
+    pub name: String,
+
+    /// Classification of the final canonical type.
+    pub kind: TypedefKind,
+
+    /// Immediate next link in the alias chain — what `typedef X Y;` was
+    /// written against. For `HANDLE`, this is `"PVOID"`. For
+    /// `LARGE_INTEGER`, this is `"_LARGE_INTEGER"` (the struct).
+    pub typedef_of: String,
+
+    /// Final canonical display, after walking every intermediate typedef.
+    /// For `HANDLE`, this is `"void *"`. For `LARGE_INTEGER`, this is
+    /// `"_LARGE_INTEGER"`.
+    pub canonical: String,
+
+    /// Canonical declaration name when the chain ends at a named
+    /// `struct`/`union`/`enum`/`class` declaration. `None` for pointer,
+    /// primitive, or anonymous-record typedefs.
+    ///
+    /// This is the field used to attach `aliases` back to a [`Struct`].
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub canonical_decl_name: Option<String>,
+
+    /// Every step from `name` (exclusive) to `canonical` (inclusive).
+    /// For `HANDLE`, this is `["PVOID", "void *"]`. For a single-step
+    /// typedef like `LARGE_INTEGER`, this is `["_LARGE_INTEGER"]`.
+    pub chain: Vec<String>,
+
+    /// Source location of the `typedef` declaration, when available.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub location: Option<SourceLocation>,
+}
+
+/// Translation-unit-scoped index of every typedef declaration.
+///
+/// Build once after parsing with [`TypedefIndex::build`], then query
+/// repeatedly. Lookup is O(1) on the typedef name; alias-reverse lookup is
+/// O(1) on the canonical decl name.
+#[derive(Debug, Default, Clone)]
+pub struct TypedefIndex {
+    by_name: HashMap<String, Typedef>,
+    aliases_by_canonical: HashMap<String, Vec<String>>,
+}
+
+impl TypedefIndex {
+    /// Walk a translation unit and collect every [`EntityKind::TypedefDecl`]
+    /// at the top level.
+    ///
+    /// Typedefs whose underlying type cannot be resolved (anonymous in a way
+    /// that produces no display name, or chains that hit a `None` from
+    /// libclang) are skipped silently — partial information is more useful
+    /// than a hard failure.
+    #[must_use]
+    pub fn build(tu: &TranslationUnit<'_>) -> Self {
+        let mut by_name: HashMap<String, Typedef> = HashMap::new();
+        let mut aliases_by_canonical: HashMap<String, Vec<String>> = HashMap::new();
+
+        for entity in tu.get_entity().get_children() {
+            if entity.get_kind() != EntityKind::TypedefDecl {
+                continue;
+            }
+            let Some(td) = Self::build_one(&entity) else {
+                continue;
+            };
+
+            if let Some(canonical_decl) = td.canonical_decl_name.as_ref() {
+                aliases_by_canonical
+                    .entry(canonical_decl.clone())
+                    .or_default()
+                    .push(td.name.clone());
+            }
+
+            // Last writer wins on duplicate names (multiple TU includes of
+            // the same header through different inclusion paths).
+            by_name.insert(td.name.clone(), td);
+        }
+
+        // Stable, deterministic alias ordering.
+        for aliases in aliases_by_canonical.values_mut() {
+            aliases.sort();
+            aliases.dedup();
+        }
+
+        Self {
+            by_name,
+            aliases_by_canonical,
+        }
+    }
+
+    /// Look up a typedef by its declared name.
+    #[must_use]
+    pub fn lookup(&self, name: &str) -> Option<&Typedef> {
+        self.by_name.get(name)
+    }
+
+    /// Typedef aliases that resolve to a given canonical declaration name.
+    ///
+    /// Returns an empty slice when no typedef points to this declaration.
+    #[must_use]
+    pub fn aliases_for(&self, canonical_decl_name: &str) -> &[String] {
+        self.aliases_by_canonical
+            .get(canonical_decl_name)
+            .map(Vec::as_slice)
+            .unwrap_or(&[])
+    }
+
+    /// Find every typedef whose name matches `pattern` under `case_sensitive`
+    /// glob matching. Used by `bb-types -s …` when the search pattern hits
+    /// no struct.
+    #[must_use]
+    pub fn match_pattern(&self, pattern: &str, case_sensitive: bool) -> Vec<&Typedef> {
+        let mut out: Vec<&Typedef> = self
+            .by_name
+            .values()
+            .filter(|t| bb_shared::glob_match(&t.name, pattern, case_sensitive))
+            .collect();
+        out.sort_by(|a, b| a.name.cmp(&b.name));
+        out
+    }
+
+    /// Every typedef name in the index, for "did you mean" suggestion lists.
+    pub fn names(&self) -> impl Iterator<Item = &str> {
+        self.by_name.keys().map(String::as_str)
+    }
+
+    /// Iterator over every collected [`Typedef`], for testing and tooling.
+    pub fn iter(&self) -> impl Iterator<Item = &Typedef> {
+        self.by_name.values()
+    }
+
+    /// Number of typedef entries collected.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.by_name.len()
+    }
+
+    /// `true` when no typedefs were collected.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.by_name.is_empty()
+    }
+}
+
+/* ─────────────────────────────── Internals ──────────────────────────────── */
+
+impl TypedefIndex {
+    /// Build a single [`Typedef`] from a [`EntityKind::TypedefDecl`] entity.
+    ///
+    /// Returns `None` if the entity is unnamed, has no usable underlying
+    /// type, or chains to something we can't represent.
+    fn build_one(entity: &Entity<'_>) -> Option<Typedef> {
+        let name = entity.get_name()?;
+        let underlying = entity.get_typedef_underlying_type()?;
+
+        // First link in the chain: the *spelled* alias target, normalized
+        // (`_LARGE_INTEGER` rather than `union _LARGE_INTEGER`, `PVOID`
+        // rather than `PVOID`, `void *` kept as-is).
+        let typedef_of = clean_type_name(&underlying);
+
+        // Walk the chain step-by-step, recording each link. After every
+        // typedef link, the next type may itself be a typedef entity —
+        // libclang exposes this via TypeKind::Typedef and a declaration
+        // with its own get_typedef_underlying_type.
+        let mut chain: Vec<String> = Vec::new();
+        let mut current = underlying;
+        let mut guard = 0_usize;
+        loop {
+            chain.push(clean_type_name(&current));
+
+            if current.get_kind() != TypeKind::Typedef {
+                break;
+            }
+            let Some(decl) = current.get_declaration() else {
+                break;
+            };
+            let Some(next) = decl.get_typedef_underlying_type() else {
+                break;
+            };
+            current = next;
+
+            guard += 1;
+            if guard > 64 {
+                // Defensive: walk shouldn't cycle for well-formed headers,
+                // but cap iterations rather than spinning forever.
+                break;
+            }
+        }
+
+        // The terminal type is the canonical form for our purposes.
+        let canonical_type = current;
+        let canonical = chain
+            .last()
+            .cloned()
+            .unwrap_or_else(|| clean_type_name(&canonical_type));
+
+        let kind = classify(&canonical_type);
+        let canonical_decl_name = match kind {
+            TypedefKind::Struct | TypedefKind::Union | TypedefKind::Enum => {
+                let is_anon = canonical_type.is_anonymous().unwrap_or(false);
+                if is_anon {
+                    None
+                } else {
+                    canonical_type.get_declaration().and_then(|d| d.get_name())
+                }
+            }
+            _ => None,
+        };
+
+        let location = SourceLocation::try_from(entity).ok();
+
+        Some(Typedef {
+            name,
+            kind,
+            typedef_of,
+            canonical,
+            canonical_decl_name,
+            chain,
+            location,
+        })
+    }
+}
+
+/// Normalize a [`Type`] to a clean display string suitable for API output.
+///
+/// For struct/union/enum types, drops the leading `struct `/`union `/
+/// `enum ` keyword that `Type::get_display_name` includes — programmers
+/// have the `kind` field for that distinction, so the keyword would just
+/// be redundant noise in cross-references. For typedef and pointer/array
+/// types, falls back to the display name (which is already clean).
+fn clean_type_name(ty: &Type<'_>) -> String {
+    // For typedef types, the display name *is* the typedef alias name
+    // (e.g. "PVOID", "HANDLE"). That's exactly what we want for chain
+    // intermediates.
+    if ty.get_kind() == TypeKind::Typedef {
+        return ty.get_display_name();
+    }
+    // For records/enums with a named declaration, use the bare decl name.
+    if let Some(decl) = ty.get_declaration()
+        && let Some(name) = decl.get_name()
+    {
+        return name;
+    }
+    // Pointers, arrays, primitives, and anonymous records: clang's
+    // display name is already the right thing (`void *`, `int`, etc.).
+    ty.get_display_name()
+}
+
+/// Classify the terminal type of a typedef chain.
+fn classify(ty: &Type<'_>) -> TypedefKind {
+    let canonical = ty.get_canonical_type();
+    let kind = canonical.get_kind();
+
+    // Function pointer detection requires looking through the pointee.
+    if let Some(pointee) = canonical.get_pointee_type() {
+        if matches!(
+            pointee.get_canonical_type().get_kind(),
+            TypeKind::FunctionPrototype | TypeKind::FunctionNoPrototype
+        ) {
+            return TypedefKind::FunctionPointer;
+        }
+        return TypedefKind::Pointer;
+    }
+
+    match kind {
+        TypeKind::Record => match canonical
+            .get_declaration()
+            .map(|d| d.get_kind())
+            .unwrap_or(EntityKind::UnexposedDecl)
+        {
+            EntityKind::UnionDecl => TypedefKind::Union,
+            EntityKind::StructDecl | EntityKind::ClassDecl => TypedefKind::Struct,
+            _ => TypedefKind::Struct,
+        },
+        TypeKind::Enum => TypedefKind::Enum,
+        TypeKind::ConstantArray | TypeKind::IncompleteArray | TypeKind::VariableArray => {
+            TypedefKind::Array
+        }
+        TypeKind::Void
+        | TypeKind::Bool
+        | TypeKind::CharS
+        | TypeKind::CharU
+        | TypeKind::SChar
+        | TypeKind::UChar
+        | TypeKind::WChar
+        | TypeKind::Char16
+        | TypeKind::Char32
+        | TypeKind::Short
+        | TypeKind::UShort
+        | TypeKind::Int
+        | TypeKind::UInt
+        | TypeKind::Long
+        | TypeKind::ULong
+        | TypeKind::LongLong
+        | TypeKind::ULongLong
+        | TypeKind::Int128
+        | TypeKind::UInt128
+        | TypeKind::Half
+        | TypeKind::Float
+        | TypeKind::Double
+        | TypeKind::LongDouble
+        | TypeKind::Float128
+        | TypeKind::Nullptr => TypedefKind::Primitive,
+        _ => TypedefKind::Other,
+    }
+}

--- a/crates/bb-clang/src/typedef.rs
+++ b/crates/bb-clang/src/typedef.rs
@@ -81,14 +81,10 @@ pub struct Typedef {
     /// distinguishable from `is_function_pointer`, for example).
     pub kind: TypedefKind,
 
-    /// Immediate next link in the alias chain — what `typedef X Y;` was
-    /// written against. For `HANDLE`, this is `"PVOID"`. For
-    /// `LARGE_INTEGER`, this is `"_LARGE_INTEGER"` (the struct).
-    pub typedef_of: String,
-
     /// Final canonical display, after walking every intermediate typedef.
     /// For `HANDLE`, this is `"void *"`. For `LARGE_INTEGER`, this is
-    /// `"_LARGE_INTEGER"`.
+    /// `"_LARGE_INTEGER"`. Equal to `chain.last()`; kept as a top-level
+    /// field for ergonomics ("just give me the resolved name").
     pub canonical: String,
 
     /// Canonical declaration name when the chain ends at a named
@@ -102,8 +98,11 @@ pub struct Typedef {
     pub canonical_decl_name: Option<String>,
 
     /// Every step from `name` (exclusive) to `canonical` (inclusive).
-    /// For `HANDLE`, this is `["PVOID", "void *"]`. For a single-step
-    /// typedef like `LARGE_INTEGER`, this is `["_LARGE_INTEGER"]`.
+    /// `chain.first()` is the immediate alias target (what `typedef X Y;`
+    /// was written against); `chain.last()` equals `canonical`. For
+    /// `HANDLE` (when defined as `typedef PVOID HANDLE`), this is
+    /// `["PVOID", "void *"]`. For a single-step typedef like
+    /// `LARGE_INTEGER`, this is `["_LARGE_INTEGER"]`.
     pub chain: Vec<String>,
 
     /// Full type metadata, flattened into this object's JSON output so
@@ -247,11 +246,6 @@ impl TypedefIndex {
         // Field/Param — programmers see the same vocabulary everywhere.
         let properties = TypeProperties::from_type(&entity_type);
 
-        // First link in the chain: the *spelled* alias target, normalized
-        // (`_LARGE_INTEGER` rather than `union _LARGE_INTEGER`, `PVOID`
-        // rather than `PVOID`, `void *` kept as-is).
-        let typedef_of = clean_type_name(&underlying);
-
         // Walk the chain step-by-step, recording each link. After every
         // typedef link, the next type may itself be a typedef entity —
         // libclang exposes this via TypeKind::Typedef and a declaration
@@ -306,7 +300,6 @@ impl TypedefIndex {
         Some(Typedef {
             name,
             kind,
-            typedef_of,
             canonical,
             canonical_decl_name,
             chain,

--- a/crates/bb-clang/src/typedef.rs
+++ b/crates/bb-clang/src/typedef.rs
@@ -56,20 +56,7 @@ pub enum TypedefKind {
     Array,
     /// Canonical type is a builtin scalar (int, void, char, ...).
     Primitive,
-    /// Anything else we don't classify. Shows up for:
-    ///
-    /// - C++ template instantiations (`typedef std::vector<int> IntVec;`).
-    ///   Clang surfaces these as `TypeKind::Unexposed` or similar template
-    ///   kinds that don't map cleanly to record / pointer / primitive.
-    /// - Dependent types in templates (`typedef typename T::value_type V;`).
-    /// - Member function pointers (`typedef int (Foo::*Fn)(int);`).
-    /// - SAL-annotated typedefs whose canonical is an unexposed attributed
-    ///   wrapper that clang doesn't unwrap further.
-    ///
-    /// In practice these don't appear in the Windows SDK / PHNT chains
-    /// we currently parse (those are C, not C++). Treat `Other` as a
-    /// signal that downstream rendering should fall back to the raw
-    /// `canonical` string rather than assume a structural shape.
+    /// Anything else we don't classify.
     Other,
 }
 
@@ -177,9 +164,7 @@ impl TypedefIndex {
         // Accumulate via HashSet so duplicate typedef declarations
         // (same name seen through different include paths) collapse at
         // insertion time instead of fanning out into the Vec and
-        // getting deduped at the end. Headers like winnt.h with deep
-        // re-inclusion would otherwise push the same alias 10+ times
-        // per canonical before the sort/dedup pass.
+        // getting deduped at the end.
         let mut alias_sets: HashMap<String, std::collections::HashSet<String>> = HashMap::new();
 
         for entity in tu.get_entity().get_children() {

--- a/crates/bb-clang/src/typedef.rs
+++ b/crates/bb-clang/src/typedef.rs
@@ -73,6 +73,26 @@ pub enum TypedefKind {
     Other,
 }
 
+impl TypedefKind {
+    /// Human-readable label for CLI / TUI rendering. Mirrors the
+    /// snake-case JSON serialization for everything except
+    /// [`Self::FunctionPointer`], which renders with a space for
+    /// readability.
+    #[must_use]
+    pub const fn label(self) -> &'static str {
+        match self {
+            Self::Struct => "struct",
+            Self::Union => "union",
+            Self::Enum => "enum",
+            Self::FunctionPointer => "function pointer",
+            Self::Pointer => "pointer",
+            Self::Array => "array",
+            Self::Primitive => "primitive",
+            Self::Other => "other",
+        }
+    }
+}
+
 /// A single typedef entry: name + chain + canonical resolution +
 /// full type metadata (flattened from [`TypeProperties`]).
 ///

--- a/crates/bb-clang/src/typedef.rs
+++ b/crates/bb-clang/src/typedef.rs
@@ -31,7 +31,7 @@ use serde::Serialize;
 
 use crate::ext::AnonymousType;
 use crate::location::SourceLocation;
-use crate::type_info::TypeProperties;
+use crate::type_info::{TypeProperties, is_array_kind, is_function_pointer, is_primitive_kind};
 
 /* ────────────────────────────────── Types ───────────────────────────────── */
 
@@ -335,22 +335,23 @@ fn clean_type_name(ty: &Type<'_>) -> String {
 }
 
 /// Classify the terminal type of a typedef chain.
+///
+/// Delegates kind-set membership to the shared helpers in
+/// [`crate::type_info`] (`is_primitive_kind`, `is_array_kind`,
+/// `is_function_pointer`) so the lists of primitive/array `TypeKind`
+/// variants live in exactly one place — no inlined repetition.
 fn classify(ty: &Type<'_>) -> TypedefKind {
     let canonical = ty.get_canonical_type();
-    let kind = canonical.get_kind();
 
     // Function pointer detection requires looking through the pointee.
-    if let Some(pointee) = canonical.get_pointee_type() {
-        if matches!(
-            pointee.get_canonical_type().get_kind(),
-            TypeKind::FunctionPrototype | TypeKind::FunctionNoPrototype
-        ) {
+    if canonical.get_pointee_type().is_some() {
+        if is_function_pointer(&canonical) {
             return TypedefKind::FunctionPointer;
         }
         return TypedefKind::Pointer;
     }
 
-    match kind {
+    match canonical.get_kind() {
         TypeKind::Record => match canonical
             .get_declaration()
             .map(|d| d.get_kind())
@@ -361,34 +362,8 @@ fn classify(ty: &Type<'_>) -> TypedefKind {
             _ => TypedefKind::Struct,
         },
         TypeKind::Enum => TypedefKind::Enum,
-        TypeKind::ConstantArray | TypeKind::IncompleteArray | TypeKind::VariableArray => {
-            TypedefKind::Array
-        }
-        TypeKind::Void
-        | TypeKind::Bool
-        | TypeKind::CharS
-        | TypeKind::CharU
-        | TypeKind::SChar
-        | TypeKind::UChar
-        | TypeKind::WChar
-        | TypeKind::Char16
-        | TypeKind::Char32
-        | TypeKind::Short
-        | TypeKind::UShort
-        | TypeKind::Int
-        | TypeKind::UInt
-        | TypeKind::Long
-        | TypeKind::ULong
-        | TypeKind::LongLong
-        | TypeKind::ULongLong
-        | TypeKind::Int128
-        | TypeKind::UInt128
-        | TypeKind::Half
-        | TypeKind::Float
-        | TypeKind::Double
-        | TypeKind::LongDouble
-        | TypeKind::Float128
-        | TypeKind::Nullptr => TypedefKind::Primitive,
+        x if is_array_kind(x) => TypedefKind::Array,
+        x if is_primitive_kind(x) => TypedefKind::Primitive,
         _ => TypedefKind::Other,
     }
 }

--- a/crates/bb-clang/src/typedef.rs
+++ b/crates/bb-clang/src/typedef.rs
@@ -31,6 +31,7 @@ use serde::Serialize;
 
 use crate::ext::AnonymousType;
 use crate::location::SourceLocation;
+use crate::type_info::TypeProperties;
 
 /* ────────────────────────────────── Types ───────────────────────────────── */
 
@@ -59,17 +60,25 @@ pub enum TypedefKind {
     Other,
 }
 
-/// A single typedef entry: name + chain + canonical resolution + classification.
+/// A single typedef entry: name + chain + canonical resolution +
+/// full type metadata (flattened from [`TypeProperties`]).
 ///
-/// Serializes to a flat JSON object suitable for inclusion in the
-/// `typedefs` array of `bb-types` output. All names use the human-readable
-/// form (matches `Type::get_display_name`).
+/// Serializes to a flat JSON object whose shape is identical to what
+/// fields and params expose for their own types — programmers get the
+/// same vocabulary (`is_pointer`, `pointer_depth`, `is_function_pointer`,
+/// `underlying_type` for the terminal primitive, `underlying_record` for
+/// the pointee record name, etc.) regardless of which entity they're
+/// looking at. That's the contract that lets a generic `inspect_type`
+/// helper accept any of these without branching.
 #[derive(Debug, Clone, Serialize)]
 pub struct Typedef {
     /// Typedef name as declared (e.g. `"LARGE_INTEGER"`, `"HANDLE"`).
     pub name: String,
 
-    /// Classification of the final canonical type.
+    /// Categorical classification of the final canonical type. Programmers
+    /// can switch on this rather than parsing the booleans below; the
+    /// booleans give the full picture (`Pointer` vs `FunctionPointer` is
+    /// distinguishable from `is_function_pointer`, for example).
     pub kind: TypedefKind,
 
     /// Immediate next link in the alias chain — what `typedef X Y;` was
@@ -83,10 +92,12 @@ pub struct Typedef {
     pub canonical: String,
 
     /// Canonical declaration name when the chain ends at a named
-    /// `struct`/`union`/`enum`/`class` declaration. `None` for pointer,
-    /// primitive, or anonymous-record typedefs.
+    /// `struct`/`union`/`enum`/`class` declaration **directly** (no
+    /// intervening pointer or array). `None` for pointer typedefs even
+    /// when they point at a named record — use the flattened
+    /// `underlying_record` for that case.
     ///
-    /// This is the field used to attach `aliases` back to a [`Struct`].
+    /// Used to attach `aliases` back to a [`Struct`](crate::Struct).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub canonical_decl_name: Option<String>,
 
@@ -94,6 +105,15 @@ pub struct Typedef {
     /// For `HANDLE`, this is `["PVOID", "void *"]`. For a single-step
     /// typedef like `LARGE_INTEGER`, this is `["_LARGE_INTEGER"]`.
     pub chain: Vec<String>,
+
+    /// Full type metadata, flattened into this object's JSON output so
+    /// the shape matches `Field` and `Param`. Contains qualifiers,
+    /// pointer/array classification, the terminal `underlying_type`
+    /// primitive (e.g. `"void"` for `HANDLE`), and the
+    /// `underlying_record` decl name (e.g. `"_LARGE_INTEGER"` for
+    /// `LARGE_INTEGER`).
+    #[serde(flatten)]
+    pub properties: TypeProperties,
 
     /// Source location of the `typedef` declaration, when available.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -219,7 +239,13 @@ impl TypedefIndex {
     /// type, or chains to something we can't represent.
     fn build_one(entity: &Entity<'_>) -> Option<Typedef> {
         let name = entity.get_name()?;
+        let entity_type = entity.get_type()?;
         let underlying = entity.get_typedef_underlying_type()?;
+
+        // Compute the full type metadata from the typedef's own clang
+        // type. This is what makes the JSON shape compatible with
+        // Field/Param — programmers see the same vocabulary everywhere.
+        let properties = TypeProperties::from_type(&entity_type);
 
         // First link in the chain: the *spelled* alias target, normalized
         // (`_LARGE_INTEGER` rather than `union _LARGE_INTEGER`, `PVOID`
@@ -284,6 +310,7 @@ impl TypedefIndex {
             canonical,
             canonical_decl_name,
             chain,
+            properties,
             location,
         })
     }

--- a/crates/bb-clang/src/typedef.rs
+++ b/crates/bb-clang/src/typedef.rs
@@ -56,7 +56,20 @@ pub enum TypedefKind {
     Array,
     /// Canonical type is a builtin scalar (int, void, char, ...).
     Primitive,
-    /// Anything else we don't classify (templates, dependent types, ...).
+    /// Anything else we don't classify. Shows up for:
+    ///
+    /// - C++ template instantiations (`typedef std::vector<int> IntVec;`).
+    ///   Clang surfaces these as `TypeKind::Unexposed` or similar template
+    ///   kinds that don't map cleanly to record / pointer / primitive.
+    /// - Dependent types in templates (`typedef typename T::value_type V;`).
+    /// - Member function pointers (`typedef int (Foo::*Fn)(int);`).
+    /// - SAL-annotated typedefs whose canonical is an unexposed attributed
+    ///   wrapper that clang doesn't unwrap further.
+    ///
+    /// In practice these don't appear in the Windows SDK / PHNT chains
+    /// we currently parse (those are C, not C++). Treat `Other` as a
+    /// signal that downstream rendering should fall back to the raw
+    /// `canonical` string rather than assume a structural shape.
     Other,
 }
 
@@ -141,7 +154,13 @@ impl TypedefIndex {
     #[must_use]
     pub fn build(tu: &TranslationUnit<'_>) -> Self {
         let mut by_name: HashMap<String, Typedef> = HashMap::new();
-        let mut aliases_by_canonical: HashMap<String, Vec<String>> = HashMap::new();
+        // Accumulate via HashSet so duplicate typedef declarations
+        // (same name seen through different include paths) collapse at
+        // insertion time instead of fanning out into the Vec and
+        // getting deduped at the end. Headers like winnt.h with deep
+        // re-inclusion would otherwise push the same alias 10+ times
+        // per canonical before the sort/dedup pass.
+        let mut alias_sets: HashMap<String, std::collections::HashSet<String>> = HashMap::new();
 
         for entity in tu.get_entity().get_children() {
             if entity.get_kind() != EntityKind::TypedefDecl {
@@ -152,10 +171,10 @@ impl TypedefIndex {
             };
 
             if let Some(canonical_decl) = td.canonical_decl_name.as_ref() {
-                aliases_by_canonical
+                alias_sets
                     .entry(canonical_decl.clone())
                     .or_default()
-                    .push(td.name.clone());
+                    .insert(td.name.clone());
             }
 
             // Last writer wins on duplicate names (multiple TU includes of
@@ -163,11 +182,15 @@ impl TypedefIndex {
             by_name.insert(td.name.clone(), td);
         }
 
-        // Stable, deterministic alias ordering.
-        for aliases in aliases_by_canonical.values_mut() {
-            aliases.sort();
-            aliases.dedup();
-        }
+        // Materialize to sorted Vecs for stable, deterministic output.
+        let aliases_by_canonical: HashMap<String, Vec<String>> = alias_sets
+            .into_iter()
+            .map(|(k, set)| {
+                let mut v: Vec<String> = set.into_iter().collect();
+                v.sort();
+                (k, v)
+            })
+            .collect();
 
         Self {
             by_name,
@@ -252,7 +275,12 @@ impl TypedefIndex {
         // with its own get_typedef_underlying_type.
         let mut chain: Vec<String> = Vec::new();
         let mut current = underlying;
-        let mut guard = 0_usize;
+        // Cap to detect runaway recursion on malformed headers. Real
+        // SDK chains are at most 3–4 deep; 64 leaves plenty of headroom
+        // while still catching cycles. Truncation emits an `eprintln!`
+        // so it surfaces during development instead of silently
+        // producing a wrong canonical.
+        const MAX_CHAIN: usize = 64;
         loop {
             chain.push(clean_type_name(&current));
 
@@ -267,10 +295,12 @@ impl TypedefIndex {
             };
             current = next;
 
-            guard += 1;
-            if guard > 64 {
-                // Defensive: walk shouldn't cycle for well-formed headers,
-                // but cap iterations rather than spinning forever.
+            if chain.len() >= MAX_CHAIN {
+                eprintln!(
+                    "bb-clang: typedef chain for `{name}` exceeded {MAX_CHAIN} steps; \
+                     truncating at `{}` — chain may not reflect the true canonical",
+                    chain.last().map(String::as_str).unwrap_or("<?>")
+                );
                 break;
             }
         }
@@ -311,11 +341,15 @@ impl TypedefIndex {
 
 /// Normalize a [`Type`] to a clean display string suitable for API output.
 ///
-/// For struct/union/enum types, drops the leading `struct `/`union `/
-/// `enum ` keyword that `Type::get_display_name` includes — programmers
-/// have the `kind` field for that distinction, so the keyword would just
-/// be redundant noise in cross-references. For typedef and pointer/array
-/// types, falls back to the display name (which is already clean).
+/// For struct/class/union/enum types, drops the leading
+/// `struct `/`class `/`union `/`enum ` keyword that
+/// `Type::get_display_name` includes — programmers have the `kind`
+/// field for that distinction, so the keyword would just be redundant
+/// noise in cross-references. For typedef and pointer/array types,
+/// falls back to the display name (already clean) but strips the same
+/// keyword prefixes in case clang surfaces an elaborated form (rare —
+/// happens for some C++ template instantiations and anonymous
+/// records).
 fn clean_type_name(ty: &Type<'_>) -> String {
     // For typedef types, the display name *is* the typedef alias name
     // (e.g. "PVOID", "HANDLE"). That's exactly what we want for chain
@@ -331,7 +365,15 @@ fn clean_type_name(ty: &Type<'_>) -> String {
     }
     // Pointers, arrays, primitives, and anonymous records: clang's
     // display name is already the right thing (`void *`, `int`, etc.).
-    ty.get_display_name()
+    // Defensively strip elaborated `struct ` / `class ` / `union ` /
+    // `enum ` prefixes if any leaked through (some C++ headers do).
+    let raw = ty.get_display_name();
+    for prefix in ["struct ", "class ", "union ", "enum "] {
+        if let Some(rest) = raw.strip_prefix(prefix) {
+            return rest.to_string();
+        }
+    }
+    raw
 }
 
 /// Classify the terminal type of a typedef chain.

--- a/crates/bb-clang/src/union_/mod.rs
+++ b/crates/bb-clang/src/union_/mod.rs
@@ -1,0 +1,231 @@
+//! Union type representation.
+//!
+//! Parallel to [`Struct`](crate::Struct) but accepts only
+//! [`EntityKind::UnionDecl`]. Unions are NOT findable as top-level
+//! entries via `bb-types -s ...` — they surface only via the
+//! `referenced_unions` slot of a struct (or another union) that has
+//! the union as a field type. Named unions (`_LARGE_INTEGER`) live
+//! there alongside anonymous nested unions (`_OVERLAPPED::<anonymous_0>`).
+
+use clang::{Entity, EntityKind};
+use serde::Serialize;
+use std::collections::HashSet;
+
+use crate::error::UnionError;
+use crate::ext::AnonymousType;
+use crate::location::SourceLocation;
+use crate::record::RecordKind;
+use crate::struct_::{Field, Struct, collect_fields, collect_nested_from_fields};
+
+/* ────────────────────────────────── Types ───────────────────────────────── */
+
+#[derive(Debug, Serialize)]
+pub struct Union<'a> {
+    #[serde(skip)]
+    entity: Entity<'a>,
+    name: String,
+    /// Always [`RecordKind::Union`]. Carried so JSON consumers can
+    /// dispatch on `kind` uniformly across struct and union entries.
+    kind: RecordKind,
+    /// Typedef names that resolve to this union (e.g.
+    /// `["LARGE_INTEGER"]` for `_LARGE_INTEGER`). Populated by callers
+    /// that have a [`TypedefIndex`](crate::TypedefIndex). Mirrors
+    /// [`Struct::get_aliases`](crate::Struct::get_aliases).
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    aliases: Vec<String>,
+    #[serde(skip_serializing_if = "std::ops::Not::not")]
+    is_anonymous: bool,
+    /// Outermost named ancestor — `Some` only for anonymous nested
+    /// unions surfaced in a parent's `referenced_unions` slot.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    enclosing_record: Option<String>,
+    /// Field-name chain from `enclosing_record` to this union. Empty
+    /// for named top-level unions.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    field_path: Vec<String>,
+    location: Option<SourceLocation>,
+    size: Option<usize>,
+    fields: Vec<Field<'a>>,
+}
+
+impl<'a> Union<'a> {
+    #[must_use]
+    pub const fn get_entity(&self) -> &Entity<'a> {
+        &self.entity
+    }
+    #[must_use]
+    pub fn get_name(&self) -> &str {
+        &self.name
+    }
+    #[must_use]
+    pub fn get_fields(&self) -> &[Field<'a>] {
+        &self.fields
+    }
+    #[must_use]
+    pub const fn get_location(&self) -> Option<&SourceLocation> {
+        self.location.as_ref()
+    }
+    #[must_use]
+    pub const fn get_size(&self) -> Option<usize> {
+        self.size
+    }
+    #[must_use]
+    pub const fn is_anonymous(&self) -> bool {
+        self.is_anonymous
+    }
+    #[must_use]
+    pub const fn kind(&self) -> RecordKind {
+        self.kind
+    }
+    #[must_use]
+    pub fn get_enclosing_record(&self) -> Option<&str> {
+        self.enclosing_record.as_deref()
+    }
+    #[must_use]
+    pub fn get_field_path(&self) -> &[String] {
+        &self.field_path
+    }
+
+    /// Typedef names that resolve to this union.
+    #[must_use]
+    pub fn get_aliases(&self) -> &[String] {
+        &self.aliases
+    }
+
+    /// Attach typedef alias names. Mirrors
+    /// [`Struct::with_aliases`](crate::Struct::with_aliases).
+    #[must_use]
+    pub fn with_aliases(mut self, aliases: Vec<String>) -> Self {
+        self.aliases = aliases;
+        self
+    }
+
+    /// Render this union in `WinDbg` `dt`-style format. Mirrors
+    /// [`Struct::display`](crate::Struct::display).
+    #[must_use]
+    pub fn display(
+        &self,
+        depth: usize,
+        field_filter: Option<&str>,
+        typedef_index: Option<&crate::TypedefIndex>,
+    ) -> String {
+        crate::display::render_union(self, depth, field_filter, typedef_index)
+    }
+
+    /// Stable identity for dedup across a flat nested-record list.
+    /// Mirrors [`Struct::identity`].
+    #[must_use]
+    pub fn identity(&self) -> String {
+        if self.is_anonymous {
+            format!(
+                "{}::{}",
+                self.enclosing_record.as_deref().unwrap_or(""),
+                self.field_path.join("::")
+            )
+        } else {
+            self.name.clone()
+        }
+    }
+
+    /// Names of named record types (struct or union) referenced by
+    /// this union's fields. Anonymous nested records are omitted.
+    /// Mirrors [`Struct::referenced_type_names`].
+    #[must_use]
+    pub fn referenced_type_names(&self) -> Vec<String> {
+        crate::struct_::referenced_named_record_names(&self.fields)
+    }
+
+    /// All nested record types reachable from this union's fields,
+    /// up to `max_depth` levels. Same semantics as
+    /// [`Struct::extract_nested_records`].
+    #[must_use]
+    pub fn extract_nested_records(&self, max_depth: usize) -> (Vec<Struct<'a>>, Vec<Self>) {
+        let mut structs: Vec<Struct<'a>> = Vec::new();
+        let mut unions: Vec<Self> = Vec::new();
+        let mut seen: HashSet<String> = HashSet::new();
+        seen.insert(self.identity());
+        collect_nested_from_fields(
+            &self.fields,
+            &mut structs,
+            &mut unions,
+            &mut seen,
+            max_depth,
+            0,
+        );
+        (structs, unions)
+    }
+}
+
+/* ─────────────────────────────── Conversions ────────────────────────────── */
+
+/// Generate a named [`Union`] from a `UnionDecl` entity.
+impl<'a> TryFrom<Entity<'a>> for Union<'a> {
+    type Error = UnionError;
+
+    fn try_from(entity: Entity<'a>) -> Result<Self, Self::Error> {
+        let kind = entity.get_kind();
+        if kind != EntityKind::UnionDecl {
+            return Err(UnionError::NotUnion(kind));
+        }
+        let location = SourceLocation::try_from(&entity).ok();
+        let is_anonymous = entity
+            .get_type()
+            .and_then(|t| t.is_anonymous())
+            .unwrap_or(false);
+        // A named-typed reference reaching this constructor still has
+        // a real name on the entity. Anonymous-typed unions go through
+        // `from_anon` with caller-supplied context.
+        let name = entity
+            .get_name()
+            .unwrap_or_else(|| "<anonymous union>".to_string());
+        let fields = collect_fields(&entity, &name, &[]);
+        let size = entity.get_type().and_then(|t| t.get_sizeof().ok());
+        Ok(Self {
+            entity,
+            name,
+            kind: RecordKind::Union,
+            aliases: Vec::new(),
+            is_anonymous,
+            enclosing_record: None,
+            field_path: Vec::new(),
+            location,
+            size,
+            fields,
+        })
+    }
+}
+
+impl<'a> Union<'a> {
+    /// Build a [`Union`] for an anonymous nested record, carrying the
+    /// caller-supplied identity. Used by [`Field::get_child_union`]
+    /// when the field's `anon_ref` indicates an anonymous union.
+    pub(crate) fn from_anon(
+        entity: Entity<'a>,
+        enclosing_record: String,
+        field_path: Vec<String>,
+    ) -> Result<Self, UnionError> {
+        let kind = entity.get_kind();
+        if kind != EntityKind::UnionDecl {
+            return Err(UnionError::NotUnion(kind));
+        }
+        let location = SourceLocation::try_from(&entity).ok();
+        let name = field_path
+            .last()
+            .cloned()
+            .unwrap_or_else(|| "<anonymous>".to_string());
+        let fields = collect_fields(&entity, &enclosing_record, &field_path);
+        let size = entity.get_type().and_then(|t| t.get_sizeof().ok());
+        Ok(Self {
+            entity,
+            name,
+            kind: RecordKind::Union,
+            aliases: Vec::new(),
+            is_anonymous: true,
+            enclosing_record: Some(enclosing_record),
+            field_path,
+            location,
+            size,
+            fields,
+        })
+    }
+}

--- a/tests/src/integration.rs
+++ b/tests/src/integration.rs
@@ -5,7 +5,9 @@ mod tests {
     use anyhow::Context;
     use bb_arch::reg::{X64Gpr, X86Gpr};
     use bb_arch::{Arch, MemoryOperand, ParamLocation, Register, ReturnLocation};
-    use bb_clang::{Enum, Function, Struct, ToJson, build_referred_components};
+    use bb_clang::{
+        Enum, Function, Struct, ToJson, TypedefIndex, TypedefKind, build_referred_components,
+    };
     use bb_consts_lib::{
         ConstFilter, build_lookup_table, collect_constants, collect_enums, filter_constants_by_name,
     };
@@ -14,7 +16,7 @@ mod tests {
         FuncFilter, FuncSort, ParamCountFilter, collect_funcs, collect_funcs_filtered,
     };
     use bb_sdk::{HeaderConfig, SdkMode};
-    use bb_types_lib::{StructFilter, collect_structs, iter_structs};
+    use bb_types_lib::{StructFilter, collect_structs, find_typedef_hits, iter_structs};
     use clang::{Clang, Index};
 
     /// Shorthand macro to get:
@@ -76,7 +78,7 @@ mod tests {
             header_filter: None,
             case_sensitive: true,
         };
-        let structs = collect_structs(&tu, &filter);
+        let structs = collect_structs(&tu, &filter, None);
         let guid = structs
             .into_iter()
             .next()
@@ -214,7 +216,7 @@ mod tests {
             header_filter: None,
             case_sensitive: false,
         };
-        let filtered = collect_structs(&tu, &filter);
+        let filtered = collect_structs(&tu, &filter, None);
 
         assert!(
             !filtered.is_empty(),
@@ -237,7 +239,7 @@ mod tests {
             "OVERLAPPED should have fields"
         );
 
-        let output = overlapped.display(1, None);
+        let output = overlapped.display(1, None, None);
         assert!(!output.is_empty(), "display() should produce output");
 
         Ok(())
@@ -253,7 +255,7 @@ mod tests {
             header_filter: None,
             case_sensitive: true,
         };
-        let structs = collect_structs(&tu, &filter);
+        let structs = collect_structs(&tu, &filter, None);
         let overlapped = find_struct(&structs, "_OVERLAPPED").expect("_OVERLAPPED must exist");
 
         // OVERLAPPED has nested anonymous struct/union types
@@ -547,7 +549,7 @@ mod tests {
         let size_x86 = {
             winsdk!(clang, index, tu, Arch::X86, SdkMode::User);
 
-            let structs = collect_structs(&tu, &filter);
+            let structs = collect_structs(&tu, &filter, None);
             find_struct(&structs, "_LIST_ENTRY")
                 .expect("LIST_ENTRY must exist on x86")
                 .get_size()
@@ -557,7 +559,7 @@ mod tests {
         let size_amd64 = {
             winsdk!(clang, index, tu, Arch::Amd64, SdkMode::User);
 
-            let structs = collect_structs(&tu, &filter);
+            let structs = collect_structs(&tu, &filter, None);
             find_struct(&structs, "_LIST_ENTRY")
                 .expect("LIST_ENTRY must exist on amd64")
                 .get_size()
@@ -611,7 +613,7 @@ mod tests {
             header_filter: None,
             case_sensitive: true,
         };
-        let structs = collect_structs(&tu, &filter);
+        let structs = collect_structs(&tu, &filter, None);
         let guid = structs
             .into_iter()
             .next()
@@ -638,7 +640,7 @@ mod tests {
             header_filter: None,
             case_sensitive: true,
         };
-        let structs = collect_structs(&tu, &filter);
+        let structs = collect_structs(&tu, &filter, None);
         assert!(!structs.is_empty(), "_PEB must exist");
 
         let full = structs.to_json_full();
@@ -677,7 +679,7 @@ mod tests {
             header_filter: None,
             case_sensitive: true,
         };
-        let structs = collect_structs(&tu, &filter);
+        let structs = collect_structs(&tu, &filter, None);
         let guid = structs
             .into_iter()
             .next()
@@ -1886,7 +1888,7 @@ mod tests {
             header_filter: None,
             case_sensitive: true,
         };
-        let structs = collect_structs(&tu, &filter);
+        let structs = collect_structs(&tu, &filter, None);
         let guid = structs
             .into_iter()
             .next()
@@ -1926,7 +1928,7 @@ mod tests {
             header_filter: None,
             case_sensitive: true,
         };
-        let structs = collect_structs(&tu, &filter);
+        let structs = collect_structs(&tu, &filter, None);
         let guid = structs
             .into_iter()
             .next()
@@ -1957,7 +1959,7 @@ mod tests {
             header_filter: None,
             case_sensitive: true,
         };
-        let structs = collect_structs(&tu, &filter);
+        let structs = collect_structs(&tu, &filter, None);
         let peb = structs
             .into_iter()
             .next()
@@ -1980,6 +1982,377 @@ mod tests {
         );
 
         Ok(())
+    }
+
+    /* ──────────────────────────────── Typedefs ──────────────────────────────── */
+
+    /// `TypedefIndex` resolves `LARGE_INTEGER` to the canonical
+    /// `_LARGE_INTEGER` struct, with the full chain captured.
+    #[test]
+    #[serial]
+    fn typedef_index_resolves_large_integer() -> anyhow::Result<()> {
+        winsdk!(clang, index, tu);
+
+        let idx = TypedefIndex::build(&tu);
+        let td = idx
+            .lookup("LARGE_INTEGER")
+            .ok_or_else(|| anyhow::anyhow!("LARGE_INTEGER typedef must exist"))?;
+
+        assert_eq!(td.name, "LARGE_INTEGER");
+        // LARGE_INTEGER is a union in the Windows headers.
+        assert!(
+            matches!(td.kind, TypedefKind::Struct | TypedefKind::Union),
+            "LARGE_INTEGER should resolve to a struct/union, got {:?}",
+            td.kind
+        );
+        assert_eq!(
+            td.canonical_decl_name.as_deref(),
+            Some("_LARGE_INTEGER"),
+            "canonical_decl_name should be the underlying record's name"
+        );
+        assert!(
+            td.chain.iter().any(|s| s.contains("_LARGE_INTEGER")),
+            "chain should end at _LARGE_INTEGER, got {:?}",
+            td.chain
+        );
+
+        // Reverse mapping: aliases_for(_LARGE_INTEGER) must include LARGE_INTEGER.
+        let aliases = idx.aliases_for("_LARGE_INTEGER");
+        assert!(
+            aliases.iter().any(|a| a == "LARGE_INTEGER"),
+            "_LARGE_INTEGER should have LARGE_INTEGER as an alias, got {aliases:?}"
+        );
+
+        Ok(())
+    }
+
+    /// `HANDLE` is a pointer typedef: chain ends at `void *` and the kind
+    /// is `Pointer`. No canonical struct to point to.
+    #[test]
+    #[serial]
+    fn typedef_index_resolves_handle_to_void_pointer() -> anyhow::Result<()> {
+        winsdk!(clang, index, tu);
+
+        let idx = TypedefIndex::build(&tu);
+        let handle = idx
+            .lookup("HANDLE")
+            .ok_or_else(|| anyhow::anyhow!("HANDLE typedef must exist"))?;
+
+        assert_eq!(handle.name, "HANDLE");
+        assert_eq!(handle.kind, TypedefKind::Pointer);
+        assert!(
+            handle.canonical_decl_name.is_none(),
+            "HANDLE should not have a canonical_decl_name (it bottoms out at void *), got {:?}",
+            handle.canonical_decl_name
+        );
+        assert!(
+            handle.canonical.contains("void"),
+            "HANDLE canonical should mention void, got {:?}",
+            handle.canonical
+        );
+        assert!(
+            !handle.chain.is_empty(),
+            "HANDLE chain must not be empty, got {:?}",
+            handle.chain
+        );
+        assert!(
+            handle
+                .chain
+                .last()
+                .is_some_and(|s| s.contains("void")),
+            "HANDLE chain should end at void *, got {:?}",
+            handle.chain
+        );
+
+        Ok(())
+    }
+
+    /// `bb-types -s LARGE_INTEGER` resolves through the typedef and
+    /// returns the canonical `_LARGE_INTEGER` struct with the alias
+    /// attached.
+    #[test]
+    #[serial]
+    fn typedef_lookup_finds_canonical_struct() -> anyhow::Result<()> {
+        winsdk!(clang, index, tu);
+
+        let idx = TypedefIndex::build(&tu);
+        let filter = StructFilter {
+            name_pattern: Some("LARGE_INTEGER".into()),
+            header_filter: None,
+            case_sensitive: true,
+        };
+        let structs = collect_structs(&tu, &filter, Some(&idx));
+
+        let canonical = find_struct(&structs, "_LARGE_INTEGER")
+            .ok_or_else(|| anyhow::anyhow!("typedef search should hit _LARGE_INTEGER"))?;
+        assert!(
+            canonical.get_aliases().iter().any(|a| a == "LARGE_INTEGER"),
+            "_LARGE_INTEGER should have aliases including LARGE_INTEGER, got {:?}",
+            canonical.get_aliases()
+        );
+
+        Ok(())
+    }
+
+    /// Searching by canonical name (`_LARGE_INTEGER`) still attaches the
+    /// typedef aliases to the struct, so JSON consumers always see both
+    /// names regardless of which one the user typed.
+    #[test]
+    #[serial]
+    fn canonical_lookup_still_attaches_aliases() -> anyhow::Result<()> {
+        winsdk!(clang, index, tu);
+
+        let idx = TypedefIndex::build(&tu);
+        let filter = StructFilter {
+            name_pattern: Some("_LARGE_INTEGER".into()),
+            header_filter: None,
+            case_sensitive: true,
+        };
+        let structs = collect_structs(&tu, &filter, Some(&idx));
+        let canonical = find_struct(&structs, "_LARGE_INTEGER")
+            .ok_or_else(|| anyhow::anyhow!("canonical search should find _LARGE_INTEGER"))?;
+        assert!(
+            canonical.get_aliases().iter().any(|a| a == "LARGE_INTEGER"),
+            "aliases should be attached regardless of which name was searched, got {:?}",
+            canonical.get_aliases()
+        );
+
+        Ok(())
+    }
+
+    /// The struct JSON includes a top-level `aliases` array (empathic
+    /// API shape — programmers don't have to follow a reference to learn
+    /// the typedef name).
+    #[test]
+    #[serial]
+    fn struct_json_includes_aliases_field() -> anyhow::Result<()> {
+        winsdk!(clang, index, tu);
+
+        let idx = TypedefIndex::build(&tu);
+        let filter = StructFilter {
+            name_pattern: Some("_LARGE_INTEGER".into()),
+            header_filter: None,
+            case_sensitive: true,
+        };
+        let structs = collect_structs(&tu, &filter, Some(&idx));
+        let canonical = find_struct(&structs, "_LARGE_INTEGER")
+            .ok_or_else(|| anyhow::anyhow!("must find _LARGE_INTEGER"))?;
+
+        let j = canonical.to_json();
+        let aliases = j["aliases"]
+            .as_array()
+            .expect("aliases must be an array in JSON");
+        let alias_names: Vec<&str> = aliases.iter().filter_map(serde_json::Value::as_str).collect();
+        assert!(
+            alias_names.contains(&"LARGE_INTEGER"),
+            "JSON aliases array should contain LARGE_INTEGER, got {alias_names:?}"
+        );
+
+        Ok(())
+    }
+
+    /// Typedefs that resolve to a struct expose `canonical_decl_name`,
+    /// which is how API consumers cross-reference back to the canonical
+    /// struct's `name` field. Symmetric with `Struct.aliases`.
+    #[test]
+    #[serial]
+    fn typedef_serializes_with_canonical_decl_name() -> anyhow::Result<()> {
+        winsdk!(clang, index, tu);
+
+        let idx = TypedefIndex::build(&tu);
+        let td = idx
+            .lookup("LARGE_INTEGER")
+            .ok_or_else(|| anyhow::anyhow!("LARGE_INTEGER must exist"))?;
+
+        let j = serde_json::to_value(td).expect("Typedef should serialize");
+        assert_eq!(j["name"], "LARGE_INTEGER");
+        assert_eq!(j["typedef_of"], "_LARGE_INTEGER");
+        assert_eq!(j["canonical"], "_LARGE_INTEGER");
+        assert_eq!(j["canonical_decl_name"], "_LARGE_INTEGER");
+        // SDK encodes LARGE_INTEGER as a union; older or different SDKs
+        // could use a struct. Accept both.
+        let kind_str = j["kind"].as_str().expect("kind should be a string");
+        assert!(
+            kind_str == "struct" || kind_str == "union",
+            "LARGE_INTEGER kind should be struct or union, got {kind_str:?}"
+        );
+        let chain = j["chain"].as_array().expect("chain should be an array");
+        assert!(!chain.is_empty(), "chain should not be empty");
+
+        Ok(())
+    }
+
+    /// HANDLE's JSON shape is the pointer-typedef shape: `canonical` is
+    /// `void *`, no `canonical_decl_name`, `kind` is `pointer`.
+    #[test]
+    #[serial]
+    fn typedef_handle_serializes_as_pointer() -> anyhow::Result<()> {
+        winsdk!(clang, index, tu);
+
+        let idx = TypedefIndex::build(&tu);
+        let handle = idx
+            .lookup("HANDLE")
+            .ok_or_else(|| anyhow::anyhow!("HANDLE must exist"))?;
+
+        let j = serde_json::to_value(handle).expect("HANDLE should serialize");
+        assert_eq!(j["name"], "HANDLE");
+        assert_eq!(j["kind"], "pointer");
+        assert!(
+            j["canonical"].as_str().is_some_and(|s| s.contains("void")),
+            "canonical should mention void, got {:?}",
+            j["canonical"]
+        );
+        // canonical_decl_name should be absent (skipped because None).
+        assert!(
+            j["canonical_decl_name"].is_null() || j.get("canonical_decl_name").is_none(),
+            "pointer typedef should omit canonical_decl_name, got {:?}",
+            j["canonical_decl_name"]
+        );
+
+        Ok(())
+    }
+
+    /// `find_typedef_hits` returns HANDLE when searched by its name —
+    /// this is how `bb-types -s HANDLE` surfaces a typedef-only result.
+    #[test]
+    #[serial]
+    fn typedef_only_search_finds_handle() -> anyhow::Result<()> {
+        winsdk!(clang, index, tu);
+
+        let idx = TypedefIndex::build(&tu);
+        let filter = StructFilter {
+            name_pattern: Some("HANDLE".into()),
+            header_filter: None,
+            case_sensitive: true,
+        };
+        let hits = find_typedef_hits(&idx, &filter);
+        assert!(
+            hits.iter().any(|t| t.name == "HANDLE"),
+            "search for HANDLE should yield a HANDLE typedef hit"
+        );
+
+        Ok(())
+    }
+
+    /// The `display()` renderer annotates HANDLE / PVOID / typedef'd
+    /// fields with their canonical form. This is the "expand HANDLE in
+    /// dt" check: rendered output must show both `HANDLE` and `void *`.
+    #[test]
+    #[serial]
+    fn display_annotates_pointer_typedef_fields() -> anyhow::Result<()> {
+        winsdk!(clang, index, tu);
+
+        let idx = TypedefIndex::build(&tu);
+        let filter = StructFilter {
+            name_pattern: Some("_OVERLAPPED".into()),
+            header_filter: None,
+            case_sensitive: true,
+        };
+        let structs = collect_structs(&tu, &filter, Some(&idx));
+        let overlapped = find_struct(&structs, "_OVERLAPPED")
+            .ok_or_else(|| anyhow::anyhow!("_OVERLAPPED must exist"))?;
+
+        let rendered = overlapped.display(0, None, Some(&idx));
+
+        // _OVERLAPPED has a HANDLE field (hEvent) — output must show
+        // both the typedef name and the canonical form.
+        assert!(
+            rendered.contains("HANDLE"),
+            "render must mention HANDLE field type"
+        );
+        assert!(
+            rendered.contains("void"),
+            "render must annotate HANDLE with its canonical void * form, got:\n{rendered}"
+        );
+
+        Ok(())
+    }
+
+    /// Rendered struct header shows the `[aka …]` chip when aliases are
+    /// attached. Visible in both colored and stripped output.
+    #[test]
+    #[serial]
+    fn display_renders_aliases_chip() -> anyhow::Result<()> {
+        winsdk!(clang, index, tu);
+
+        let idx = TypedefIndex::build(&tu);
+        let filter = StructFilter {
+            name_pattern: Some("_LARGE_INTEGER".into()),
+            header_filter: None,
+            case_sensitive: true,
+        };
+        let structs = collect_structs(&tu, &filter, Some(&idx));
+        let canonical = find_struct(&structs, "_LARGE_INTEGER")
+            .ok_or_else(|| anyhow::anyhow!("must find _LARGE_INTEGER"))?;
+
+        let rendered = canonical.display(0, None, Some(&idx));
+        assert!(
+            rendered.contains("[aka") && rendered.contains("LARGE_INTEGER"),
+            "header should show `[aka LARGE_INTEGER]` chip, got:\n{rendered}"
+        );
+
+        Ok(())
+    }
+
+    /// `format_abi_param` and `render_function_detail` annotate HANDLE
+    /// param types with their canonical form. This is the bb-funcs side
+    /// of the dt expansion.
+    #[test]
+    #[serial]
+    fn function_render_detail_annotates_handle_param() -> anyhow::Result<()> {
+        winsdk!(clang, index, tu);
+
+        let funcs: Vec<Function> = collect_funcs(&tu)
+            .into_iter()
+            .filter(|f| f.get_name() == "CloseHandle")
+            .collect();
+        let f = funcs
+            .first()
+            .ok_or_else(|| anyhow::anyhow!("CloseHandle must be parseable"))?;
+
+        let idx = TypedefIndex::build(&tu);
+        let rendered = f.display_detail(Some(&idx));
+
+        assert!(
+            rendered.contains("HANDLE"),
+            "CloseHandle ABI render must mention HANDLE"
+        );
+        assert!(
+            rendered.contains("void"),
+            "CloseHandle ABI render must annotate HANDLE with `(void *)`, got:\n{rendered}"
+        );
+
+        Ok(())
+    }
+
+    /// `find_typedef_hits` returns empty when the pattern is `None`.
+    #[test]
+    #[serial]
+    fn find_typedef_hits_empty_without_pattern() -> anyhow::Result<()> {
+        winsdk!(clang, index, tu);
+
+        let idx = TypedefIndex::build(&tu);
+        let filter = StructFilter {
+            name_pattern: None,
+            header_filter: None,
+            case_sensitive: false,
+        };
+        assert!(find_typedef_hits(&idx, &filter).is_empty());
+        Ok(())
+    }
+
+    /// `TypedefKind` serializes to lowercase snake_case so JSON consumers
+    /// can switch/match on string values cleanly.
+    #[test]
+    fn typedef_kind_serializes_snake_case() {
+        let v = serde_json::to_value(TypedefKind::FunctionPointer).unwrap();
+        assert_eq!(v, "function_pointer");
+
+        let v = serde_json::to_value(TypedefKind::Struct).unwrap();
+        assert_eq!(v, "struct");
+
+        let v = serde_json::to_value(TypedefKind::Pointer).unwrap();
+        assert_eq!(v, "pointer");
     }
 
     /* ───────────────────────────────── Helpers ──────────────────────────────── */

--- a/tests/src/integration.rs
+++ b/tests/src/integration.rs
@@ -16,7 +16,9 @@ mod tests {
         FuncFilter, FuncSort, ParamCountFilter, collect_funcs, collect_funcs_filtered,
     };
     use bb_sdk::{HeaderConfig, SdkMode};
-    use bb_types_lib::{StructFilter, collect_structs, find_typedef_hits, iter_structs};
+    use bb_types_lib::{
+        StructFilter, collect_structs, find_struct_by_name, find_typedef_hits, iter_structs,
+    };
     use clang::{Clang, Index};
 
     /// Shorthand macro to get:
@@ -2338,6 +2340,174 @@ mod tests {
             case_sensitive: false,
         };
         assert!(find_typedef_hits(&idx, &filter).is_empty());
+        Ok(())
+    }
+
+    /// Field JSON now carries the **primitive** at the bottom of the
+    /// canonical chain in `underlying_type` (e.g. `BOOL` → `int`,
+    /// `DWORD` → `unsigned long`). This is the new
+    /// `TypeProperties.underlying_type` semantics.
+    #[test]
+    #[serial]
+    fn field_underlying_type_is_primitive() -> anyhow::Result<()> {
+        winsdk!(clang, index, tu);
+
+        let idx = TypedefIndex::build(&tu);
+        let filter = StructFilter {
+            name_pattern: Some("_SECURITY_ATTRIBUTES".into()),
+            header_filter: None,
+            case_sensitive: true,
+        };
+        let structs = collect_structs(&tu, &filter, Some(&idx));
+        let sa = find_struct(&structs, "_SECURITY_ATTRIBUTES")
+            .ok_or_else(|| anyhow::anyhow!("_SECURITY_ATTRIBUTES must exist"))?;
+
+        let j = sa.to_json();
+        let fields = j["fields"].as_array().expect("fields array");
+
+        let n_length = fields
+            .iter()
+            .find(|f| f["name"] == "nLength")
+            .expect("nLength field");
+        assert_eq!(
+            n_length["underlying_type"], "unsigned long",
+            "DWORD's primitive should be unsigned long"
+        );
+
+        let b_inherit = fields
+            .iter()
+            .find(|f| f["name"] == "bInheritHandle")
+            .expect("bInheritHandle field");
+        assert_eq!(
+            b_inherit["underlying_type"], "int",
+            "BOOL's primitive should be int"
+        );
+
+        Ok(())
+    }
+
+    /// Typedef JSON gains a flattened `TypeProperties` so the shape
+    /// matches Field/Param entries: `is_pointer`, `pointer_depth`,
+    /// `underlying_type` (primitive), `underlying_record` (record name),
+    /// etc. all appear at the top level.
+    #[test]
+    #[serial]
+    fn typedef_json_includes_flattened_type_properties() -> anyhow::Result<()> {
+        winsdk!(clang, index, tu);
+
+        let idx = TypedefIndex::build(&tu);
+        let handle = idx.lookup("HANDLE").expect("HANDLE must exist");
+        let j = serde_json::to_value(handle).expect("Typedef serializes");
+
+        // Pointer-typedef shape: is_pointer + underlying_type primitive,
+        // no underlying_record.
+        assert_eq!(j["is_pointer"], true);
+        assert_eq!(j["pointer_depth"], 1);
+        assert_eq!(j["underlying_type"], "void");
+        assert!(
+            j.get("underlying_record").is_none_or(serde_json::Value::is_null),
+            "HANDLE should not have underlying_record (void has no record name), got {:?}",
+            j["underlying_record"]
+        );
+        assert_eq!(j["is_const"], false);
+        assert_eq!(j["is_function_pointer"], false);
+
+        // Struct-typedef shape: inverse.
+        let li = idx.lookup("LARGE_INTEGER").expect("LARGE_INTEGER must exist");
+        let j2 = serde_json::to_value(li).expect("Typedef serializes");
+        assert_eq!(j2["is_pointer"], false);
+        assert_eq!(j2["underlying_record"], "_LARGE_INTEGER");
+        assert!(
+            j2.get("underlying_type").is_none_or(serde_json::Value::is_null),
+            "LARGE_INTEGER should not have a primitive underlying_type (leaf is a union), got {:?}",
+            j2["underlying_type"]
+        );
+
+        Ok(())
+    }
+
+    /// Auto-expansion: searching a pointer typedef like
+    /// `LPSECURITY_ATTRIBUTES` should let the caller pull in the
+    /// `_SECURITY_ATTRIBUTES` struct it points to, so the response is
+    /// self-contained. Mirrors the workflow `bb-types`'s main uses to
+    /// expand `types[]` from `typedefs[]`.
+    #[test]
+    #[serial]
+    fn pointer_typedef_search_expands_to_canonical_struct() -> anyhow::Result<()> {
+        winsdk!(clang, index, tu);
+
+        let idx = TypedefIndex::build(&tu);
+        let filter = StructFilter {
+            name_pattern: Some("LPSECURITY_ATTRIBUTES".into()),
+            header_filter: None,
+            case_sensitive: true,
+        };
+
+        // Initial struct search — pointer typedef name doesn't match any
+        // struct decl name, so this comes back empty.
+        let mut structs = collect_structs(&tu, &filter, Some(&idx));
+        assert!(
+            structs.is_empty(),
+            "no struct is literally named LPSECURITY_ATTRIBUTES"
+        );
+
+        // Typedef hits surface the pointer typedef directly.
+        let hits = find_typedef_hits(&idx, &filter);
+        let lp = hits
+            .iter()
+            .find(|t| t.name == "LPSECURITY_ATTRIBUTES")
+            .ok_or_else(|| anyhow::anyhow!("LPSECURITY_ATTRIBUTES should be a typedef hit"))?;
+
+        // The hit's flattened TypeProperties point at the canonical struct.
+        assert_eq!(lp.properties.is_pointer, true);
+        assert_eq!(
+            lp.properties.underlying_record.as_deref(),
+            Some("_SECURITY_ATTRIBUTES"),
+            "pointer typedef should expose its underlying record"
+        );
+
+        // Expansion step: pull that struct in.
+        if let Some(record_name) = lp.properties.underlying_record.as_deref()
+            && let Some(s) = find_struct_by_name(&tu, record_name, Some(&idx))
+        {
+            structs.push(s);
+        }
+
+        let expanded = find_struct(&structs, "_SECURITY_ATTRIBUTES")
+            .ok_or_else(|| anyhow::anyhow!("expansion should pull in _SECURITY_ATTRIBUTES"))?;
+        assert!(
+            expanded
+                .get_aliases()
+                .iter()
+                .any(|a| a == "SECURITY_ATTRIBUTES"),
+            "expanded struct should carry the direct typedef alias, got {:?}",
+            expanded.get_aliases()
+        );
+        assert!(
+            !expanded.get_fields().is_empty(),
+            "expanded struct should have its fields populated"
+        );
+
+        Ok(())
+    }
+
+    /// `find_struct_by_name` resolves a canonical name to a single
+    /// struct with aliases attached.
+    #[test]
+    #[serial]
+    fn find_struct_by_name_attaches_aliases() -> anyhow::Result<()> {
+        winsdk!(clang, index, tu);
+
+        let idx = TypedefIndex::build(&tu);
+        let s = find_struct_by_name(&tu, "_SECURITY_ATTRIBUTES", Some(&idx))
+            .ok_or_else(|| anyhow::anyhow!("_SECURITY_ATTRIBUTES must resolve"))?;
+        assert_eq!(s.get_name(), "_SECURITY_ATTRIBUTES");
+        assert!(
+            s.get_aliases().iter().any(|a| a == "SECURITY_ATTRIBUTES"),
+            "aliases should include SECURITY_ATTRIBUTES, got {:?}",
+            s.get_aliases()
+        );
+
         Ok(())
     }
 

--- a/tests/src/integration.rs
+++ b/tests/src/integration.rs
@@ -2168,9 +2168,11 @@ mod tests {
 
         let j = serde_json::to_value(td).expect("Typedef should serialize");
         assert_eq!(j["name"], "LARGE_INTEGER");
-        assert_eq!(j["typedef_of"], "_LARGE_INTEGER");
         assert_eq!(j["canonical"], "_LARGE_INTEGER");
         assert_eq!(j["canonical_decl_name"], "_LARGE_INTEGER");
+        // chain.first() carries what typedef_of used to be; chain.last()
+        // equals canonical.
+        assert_eq!(j["chain"][0], "_LARGE_INTEGER");
         // SDK encodes LARGE_INTEGER as a union; older or different SDKs
         // could use a struct. Accept both.
         let kind_str = j["kind"].as_str().expect("kind should be a string");

--- a/tests/src/integration.rs
+++ b/tests/src/integration.rs
@@ -6,7 +6,8 @@ mod tests {
     use bb_arch::reg::{X64Gpr, X86Gpr};
     use bb_arch::{Arch, MemoryOperand, ParamLocation, Register, ReturnLocation};
     use bb_clang::{
-        Enum, Function, Struct, ToJson, TypedefIndex, TypedefKind, build_referred_components,
+        Enum, Function, RecordKind, Struct, ToJson, TypedefIndex, TypedefKind,
+        build_referred_components,
     };
     use bb_consts_lib::{
         ConstFilter, build_lookup_table, collect_constants, collect_enums, filter_constants_by_name,
@@ -17,7 +18,8 @@ mod tests {
     };
     use bb_sdk::{HeaderConfig, SdkMode};
     use bb_types_lib::{
-        StructFilter, collect_structs, find_struct_by_name, find_typedef_hits, iter_structs,
+        StructFilter, collect_structs, collect_unions, find_struct_by_name, find_typedef_hits,
+        find_union_by_name, iter_structs, iter_unions,
     };
     use clang::{Clang, Index};
 
@@ -261,15 +263,19 @@ mod tests {
         let overlapped = find_struct(&structs, "_OVERLAPPED").expect("_OVERLAPPED must exist");
 
         // OVERLAPPED has nested anonymous struct/union types
-        let nested = overlapped.extract_nested_types(2);
-        // Just verify the method runs without panicking and returns valid structs
-        for n in &nested {
-            assert!(!n.get_name().is_empty(), "nested type should have a name");
+        let (nested_structs, nested_unions) = overlapped.extract_nested_records(2);
+        // Just verify the method runs without panicking and returns valid records.
+        for n in &nested_structs {
+            assert!(!n.get_name().is_empty(), "nested struct should have a name");
+        }
+        for n in &nested_unions {
+            assert!(!n.get_name().is_empty(), "nested union should have a name");
         }
 
-        // referenced_type_names should return named child types
-        let refs = overlapped.referenced_type_names();
-        for name in &refs {
+        // referenced_type_names returns names of named child records
+        // (both structs and unions); anonymous nested records are
+        // omitted because they have no string name.
+        for name in overlapped.referenced_type_names() {
             assert!(
                 !name.is_empty(),
                 "referenced type names should be non-empty"
@@ -623,6 +629,7 @@ mod tests {
 
         let j = guid.to_json();
         assert_eq!(j["name"], "_GUID");
+        assert_eq!(j["kind"], "struct");
         assert!(j["fields"].is_array(), "should have fields array");
         assert!(
             j["referenced_types"].is_array(),
@@ -652,7 +659,8 @@ mod tests {
             "should have referenced_types array"
         );
 
-        // types entries should NOT have a referenced_types field
+        // types entries should NOT have a referenced_types field — that
+        // lives at the top level when serialized via the slice path.
         let types = full["types"].as_array().unwrap();
         for t in types {
             assert!(
@@ -662,9 +670,12 @@ mod tests {
             );
         }
 
-        // _PEB has many nested struct types
-        let refs = full["referenced_types"].as_array().unwrap();
-        assert!(!refs.is_empty(), "_PEB should have nested referenced types");
+        // _PEB has many nested struct + union types.
+        let referenced = full["referenced_types"].as_array().unwrap();
+        assert!(
+            !referenced.is_empty(),
+            "_PEB should reference at least one nested record"
+        );
 
         Ok(())
     }
@@ -2058,10 +2069,7 @@ mod tests {
             handle.chain
         );
         assert!(
-            handle
-                .chain
-                .last()
-                .is_some_and(|s| s.contains("void")),
+            handle.chain.last().is_some_and(|s| s.contains("void")),
             "HANDLE chain should end at void *, got {:?}",
             handle.chain
         );
@@ -2069,9 +2077,11 @@ mod tests {
         Ok(())
     }
 
-    /// `bb-types -s LARGE_INTEGER` resolves through the typedef and
-    /// returns the canonical `_LARGE_INTEGER` struct with the alias
-    /// attached.
+    /// `bb-types -s FILETIME` resolves through the typedef and returns
+    /// the canonical `_FILETIME` struct with the alias attached.
+    /// (`_FILETIME` is a struct with a real typedef alias; the prior
+    /// `_LARGE_INTEGER` fixture was a union and is no longer findable
+    /// as a struct after the Union refactor.)
     #[test]
     #[serial]
     fn typedef_lookup_finds_canonical_struct() -> anyhow::Result<()> {
@@ -2079,24 +2089,24 @@ mod tests {
 
         let idx = TypedefIndex::build(&tu);
         let filter = StructFilter {
-            name_pattern: Some("LARGE_INTEGER".into()),
+            name_pattern: Some("FILETIME".into()),
             header_filter: None,
             case_sensitive: true,
         };
         let structs = collect_structs(&tu, &filter, Some(&idx));
 
-        let canonical = find_struct(&structs, "_LARGE_INTEGER")
-            .ok_or_else(|| anyhow::anyhow!("typedef search should hit _LARGE_INTEGER"))?;
+        let canonical = find_struct(&structs, "_FILETIME")
+            .ok_or_else(|| anyhow::anyhow!("typedef search should hit _FILETIME"))?;
         assert!(
-            canonical.get_aliases().iter().any(|a| a == "LARGE_INTEGER"),
-            "_LARGE_INTEGER should have aliases including LARGE_INTEGER, got {:?}",
+            canonical.get_aliases().iter().any(|a| a == "FILETIME"),
+            "_FILETIME should have aliases including FILETIME, got {:?}",
             canonical.get_aliases()
         );
 
         Ok(())
     }
 
-    /// Searching by canonical name (`_LARGE_INTEGER`) still attaches the
+    /// Searching by canonical name (`_FILETIME`) still attaches the
     /// typedef aliases to the struct, so JSON consumers always see both
     /// names regardless of which one the user typed.
     #[test]
@@ -2106,15 +2116,15 @@ mod tests {
 
         let idx = TypedefIndex::build(&tu);
         let filter = StructFilter {
-            name_pattern: Some("_LARGE_INTEGER".into()),
+            name_pattern: Some("_FILETIME".into()),
             header_filter: None,
             case_sensitive: true,
         };
         let structs = collect_structs(&tu, &filter, Some(&idx));
-        let canonical = find_struct(&structs, "_LARGE_INTEGER")
-            .ok_or_else(|| anyhow::anyhow!("canonical search should find _LARGE_INTEGER"))?;
+        let canonical = find_struct(&structs, "_FILETIME")
+            .ok_or_else(|| anyhow::anyhow!("canonical search should find _FILETIME"))?;
         assert!(
-            canonical.get_aliases().iter().any(|a| a == "LARGE_INTEGER"),
+            canonical.get_aliases().iter().any(|a| a == "FILETIME"),
             "aliases should be attached regardless of which name was searched, got {:?}",
             canonical.get_aliases()
         );
@@ -2132,22 +2142,25 @@ mod tests {
 
         let idx = TypedefIndex::build(&tu);
         let filter = StructFilter {
-            name_pattern: Some("_LARGE_INTEGER".into()),
+            name_pattern: Some("_FILETIME".into()),
             header_filter: None,
             case_sensitive: true,
         };
         let structs = collect_structs(&tu, &filter, Some(&idx));
-        let canonical = find_struct(&structs, "_LARGE_INTEGER")
-            .ok_or_else(|| anyhow::anyhow!("must find _LARGE_INTEGER"))?;
+        let canonical = find_struct(&structs, "_FILETIME")
+            .ok_or_else(|| anyhow::anyhow!("must find _FILETIME"))?;
 
         let j = canonical.to_json();
         let aliases = j["aliases"]
             .as_array()
             .expect("aliases must be an array in JSON");
-        let alias_names: Vec<&str> = aliases.iter().filter_map(serde_json::Value::as_str).collect();
+        let alias_names: Vec<&str> = aliases
+            .iter()
+            .filter_map(serde_json::Value::as_str)
+            .collect();
         assert!(
-            alias_names.contains(&"LARGE_INTEGER"),
-            "JSON aliases array should contain LARGE_INTEGER, got {alias_names:?}"
+            alias_names.contains(&"FILETIME"),
+            "JSON aliases array should contain FILETIME, got {alias_names:?}"
         );
 
         Ok(())
@@ -2273,10 +2286,42 @@ mod tests {
     }
 
     /// Rendered struct header shows the `[aka …]` chip when aliases are
-    /// attached. Visible in both colored and stripped output.
+    /// attached. Visible in both colored and stripped output. Uses
+    /// `_FILETIME` (struct + typedef `FILETIME`) since named unions
+    /// now go through the parallel `collect_unions` path.
     #[test]
     #[serial]
     fn display_renders_aliases_chip() -> anyhow::Result<()> {
+        winsdk!(clang, index, tu);
+
+        let idx = TypedefIndex::build(&tu);
+        let filter = StructFilter {
+            name_pattern: Some("_FILETIME".into()),
+            header_filter: None,
+            case_sensitive: true,
+        };
+        let structs = collect_structs(&tu, &filter, Some(&idx));
+        let canonical = find_struct(&structs, "_FILETIME")
+            .ok_or_else(|| anyhow::anyhow!("must find _FILETIME"))?;
+
+        let rendered = canonical.display(0, None, Some(&idx));
+        assert!(
+            rendered.contains("[aka") && rendered.contains("FILETIME"),
+            "header should show `[aka FILETIME]` chip, got:\n{rendered}"
+        );
+
+        Ok(())
+    }
+
+    /* ───────────────────────────────── Unions ───────────────────────────────── */
+
+    /// `_LARGE_INTEGER` is a top-level named union. It must be findable
+    /// via `collect_unions` (the union counterpart of `collect_structs`)
+    /// but NOT via `collect_structs` — the Struct/Union types are
+    /// strictly disjoint.
+    #[test]
+    #[serial]
+    fn named_union_findable_via_collect_unions() -> anyhow::Result<()> {
         winsdk!(clang, index, tu);
 
         let idx = TypedefIndex::build(&tu);
@@ -2285,14 +2330,312 @@ mod tests {
             header_filter: None,
             case_sensitive: true,
         };
-        let structs = collect_structs(&tu, &filter, Some(&idx));
-        let canonical = find_struct(&structs, "_LARGE_INTEGER")
-            .ok_or_else(|| anyhow::anyhow!("must find _LARGE_INTEGER"))?;
+        let unions = collect_unions(&tu, &filter, Some(&idx));
+        let li = unions
+            .iter()
+            .find(|u| u.get_name() == "_LARGE_INTEGER")
+            .ok_or_else(|| anyhow::anyhow!("_LARGE_INTEGER must be findable as a union"))?;
 
-        let rendered = canonical.display(0, None, Some(&idx));
+        assert_eq!(li.kind(), RecordKind::Union);
         assert!(
-            rendered.contains("[aka") && rendered.contains("LARGE_INTEGER"),
-            "header should show `[aka LARGE_INTEGER]` chip, got:\n{rendered}"
+            li.get_aliases().iter().any(|a| a == "LARGE_INTEGER"),
+            "LARGE_INTEGER must be attached as an alias"
+        );
+
+        // The same name must NOT resolve via the struct path.
+        let structs = collect_structs(&tu, &filter, Some(&idx));
+        assert!(
+            structs.is_empty(),
+            "_LARGE_INTEGER must not appear in collect_structs (it's a union)"
+        );
+
+        Ok(())
+    }
+
+    /// Typedef-name search (`LARGE_INTEGER`) reaches the canonical union
+    /// `_LARGE_INTEGER`. Mirrors `typedef_lookup_finds_canonical_struct`
+    /// for the union path.
+    #[test]
+    #[serial]
+    fn typedef_lookup_finds_canonical_union() -> anyhow::Result<()> {
+        winsdk!(clang, index, tu);
+
+        let idx = TypedefIndex::build(&tu);
+        let filter = StructFilter {
+            name_pattern: Some("LARGE_INTEGER".into()),
+            header_filter: None,
+            case_sensitive: true,
+        };
+        let unions = collect_unions(&tu, &filter, Some(&idx));
+        let li = unions
+            .iter()
+            .find(|u| u.get_name() == "_LARGE_INTEGER")
+            .ok_or_else(|| anyhow::anyhow!("typedef LARGE_INTEGER should hit _LARGE_INTEGER"))?;
+        assert!(li.get_aliases().iter().any(|a| a == "LARGE_INTEGER"));
+
+        Ok(())
+    }
+
+    /// Union JSON shape mirrors Struct: `name`, `kind: "union"`,
+    /// `aliases`, `fields`, `referenced_types`.
+    #[test]
+    #[serial]
+    fn union_json_shape() -> anyhow::Result<()> {
+        winsdk!(clang, index, tu);
+
+        let idx = TypedefIndex::build(&tu);
+        let li = find_union_by_name(&tu, "_LARGE_INTEGER", Some(&idx))
+            .ok_or_else(|| anyhow::anyhow!("_LARGE_INTEGER must exist"))?;
+
+        let j = li.to_json();
+        assert_eq!(j["name"], "_LARGE_INTEGER");
+        assert_eq!(j["kind"], "union");
+        assert!(j["fields"].is_array(), "union must serialize fields array");
+        assert!(
+            j["referenced_types"].is_array(),
+            "union must include referenced_types slot"
+        );
+        let aliases = j["aliases"].as_array().expect("aliases must be an array");
+        let names: Vec<&str> = aliases
+            .iter()
+            .filter_map(serde_json::Value::as_str)
+            .collect();
+        assert!(
+            names.contains(&"LARGE_INTEGER"),
+            "aliases should contain LARGE_INTEGER, got {names:?}"
+        );
+
+        Ok(())
+    }
+
+    /// `_OVERLAPPED` has a nameless inner anonymous union (and inside
+    /// that, a nameless anonymous struct). The new design represents
+    /// these via synthetic `<anonymous_N>` names + an `anon_ref` on
+    /// the field that points into the parent struct's
+    /// `referenced_types` slot. The two anonymous entries (union and
+    /// inner struct) coexist in the single `referenced_types` array,
+    /// distinguished by per-entry `kind`.
+    #[test]
+    #[serial]
+    fn overlapped_anon_records_in_referenced_types() -> anyhow::Result<()> {
+        winsdk!(clang, index, tu);
+
+        let overlapped = find_struct_by_name(&tu, "_OVERLAPPED", None)
+            .ok_or_else(|| anyhow::anyhow!("_OVERLAPPED must exist"))?;
+
+        // The anonymous union field is nameless in C — Field carries a
+        // synthetic `<anonymous_N>` name and the `is_anonymous` flag.
+        let anon_field = overlapped
+            .get_fields()
+            .iter()
+            .find(|f| f.is_anonymous() && f.get_anon_ref().is_some())
+            .ok_or_else(|| {
+                anyhow::anyhow!("_OVERLAPPED must have an anonymous union field with anon_ref")
+            })?;
+
+        let aref = anon_field
+            .get_anon_ref()
+            .expect("filter selected only fields with anon_ref");
+        assert_eq!(aref.kind, RecordKind::Union);
+        assert_eq!(aref.enclosing_record, "_OVERLAPPED");
+        assert_eq!(aref.field_path.len(), 1);
+        assert!(
+            aref.field_path[0].starts_with("<anonymous_"),
+            "field_path element should be a synthetic identifier, got {:?}",
+            aref.field_path[0]
+        );
+
+        // Full JSON exposes BOTH the anonymous union and the inner
+        // anonymous struct in the single `referenced_types` slot,
+        // distinguished by per-entry `kind`.
+        let full = overlapped.to_json_full();
+        let referenced = full["referenced_types"]
+            .as_array()
+            .expect("referenced_types must be an array");
+        assert!(
+            referenced
+                .iter()
+                .any(|u| u["enclosing_record"] == "_OVERLAPPED" && u["kind"] == "union"),
+            "_OVERLAPPED's anonymous union must surface in referenced_types, got:\n{}",
+            serde_json::to_string_pretty(&full["referenced_types"]).unwrap()
+        );
+        assert!(
+            referenced
+                .iter()
+                .any(|s| s["enclosing_record"] == "_OVERLAPPED" && s["kind"] == "struct"),
+            "_OVERLAPPED's nested anonymous struct must surface in referenced_types, got:\n{}",
+            serde_json::to_string_pretty(&full["referenced_types"]).unwrap()
+        );
+
+        Ok(())
+    }
+
+    /// `iter_unions` yields only top-level (named) unions. Anonymous
+    /// unions never appear at the TU root.
+    #[test]
+    #[serial]
+    fn iter_unions_yields_named_only() -> anyhow::Result<()> {
+        winsdk!(clang, index, tu);
+
+        let names: Vec<String> = iter_unions(&tu).filter_map(|e| e.get_name()).collect();
+        assert!(
+            !names.is_empty(),
+            "expected at least some named unions (e.g. _LARGE_INTEGER)"
+        );
+        assert!(
+            names.iter().any(|n| n == "_LARGE_INTEGER"),
+            "iter_unions must include _LARGE_INTEGER"
+        );
+
+        Ok(())
+    }
+
+    /// `_OVERLAPPED`'s field list must contain exactly 4 entries
+    /// after the anon-record synthesis: three named C FieldDecls and
+    /// the synthesized union slot at the right offset. This guards
+    /// against silent regressions in `build_anon_record_field` or
+    /// `anon_record_offset_in_parent` — both of which would cause
+    /// the synthetic entry to vanish, land at offset 0, or duplicate.
+    #[test]
+    #[serial]
+    fn overlapped_synthesizes_anon_union_at_offset_16() -> anyhow::Result<()> {
+        winsdk!(clang, index, tu);
+
+        let overlapped = find_struct_by_name(&tu, "_OVERLAPPED", None)
+            .ok_or_else(|| anyhow::anyhow!("_OVERLAPPED must exist"))?;
+
+        let fields = overlapped.get_fields();
+        assert_eq!(
+            fields.len(),
+            4,
+            "_OVERLAPPED must have exactly 4 member slots (3 named + 1 synthetic anon union), got {}",
+            fields.len()
+        );
+
+        // Three named FieldDecls.
+        assert_eq!(fields[0].get_name(), "Internal");
+        assert_eq!(fields[0].get_offset_bytes(), 0);
+        assert!(!fields[0].is_anonymous());
+        assert!(fields[0].get_field_decl().is_some());
+
+        assert_eq!(fields[1].get_name(), "InternalHigh");
+        assert_eq!(fields[1].get_offset_bytes(), 8);
+
+        assert_eq!(fields[3].get_name(), "hEvent");
+        assert_eq!(fields[3].get_offset_bytes(), 24);
+
+        // Slot 2 is the synthetic anon union — non-zero offset is the
+        // critical correctness bit (the unwrap_or(0) fallback bug
+        // would have placed it at 0).
+        let anon = &fields[2];
+        assert!(anon.is_anonymous());
+        assert!(anon.get_name().starts_with("<anonymous_"));
+        assert_eq!(
+            anon.get_offset_bytes(),
+            16,
+            "synthetic anon union must sit at offset 16, got {}",
+            anon.get_offset_bytes()
+        );
+        assert_eq!(anon.get_size(), 8);
+
+        // Synthetic fields have no FieldDecl; their `entity` is the
+        // anon record decl itself.
+        assert!(
+            anon.get_field_decl().is_none(),
+            "synthetic anon entry must not expose a FieldDecl"
+        );
+
+        // anon_ref carries the cross-reference identity.
+        let aref = anon
+            .get_anon_ref()
+            .ok_or_else(|| anyhow::anyhow!("synthetic anon entry must carry anon_ref"))?;
+        assert_eq!(aref.kind, RecordKind::Union);
+        assert_eq!(aref.enclosing_record, "_OVERLAPPED");
+        assert_eq!(aref.field_path, vec!["<anonymous_0>"]);
+
+        Ok(())
+    }
+
+    /// The inner anonymous struct inside `_OVERLAPPED`'s anonymous
+    /// union appears in `referenced_types` with field_path
+    /// `["<anonymous_0>", "<anonymous_0>"]` — proving the per-parent
+    /// counter resets correctly at each nesting level (the design
+    /// invariant from the spec).
+    #[test]
+    #[serial]
+    fn overlapped_inner_anon_struct_has_nested_field_path() -> anyhow::Result<()> {
+        winsdk!(clang, index, tu);
+
+        let overlapped = find_struct_by_name(&tu, "_OVERLAPPED", None)
+            .ok_or_else(|| anyhow::anyhow!("_OVERLAPPED must exist"))?;
+
+        let full = overlapped.to_json_full();
+        let referenced = full["referenced_types"]
+            .as_array()
+            .expect("referenced_types must be an array");
+
+        let inner_struct = referenced
+            .iter()
+            .find(|e| e["kind"] == "struct" && e["enclosing_record"] == "_OVERLAPPED")
+            .ok_or_else(|| anyhow::anyhow!("inner anon struct must surface in referenced_types"))?;
+        let path: Vec<&str> = inner_struct["field_path"]
+            .as_array()
+            .expect("field_path must be array")
+            .iter()
+            .map(|v| v.as_str().unwrap_or(""))
+            .collect();
+        assert_eq!(
+            path,
+            vec!["<anonymous_0>", "<anonymous_0>"],
+            "inner anon struct must have a two-element field_path matching the nesting depth, got {path:?}"
+        );
+
+        Ok(())
+    }
+
+    /// `collect_unions` returns `_LARGE_INTEGER` with the
+    /// `LARGE_INTEGER` typedef alias attached.
+    #[test]
+    #[serial]
+    fn collect_unions_surfaces_large_integer_with_alias() -> anyhow::Result<()> {
+        winsdk!(clang, index, tu);
+
+        let idx = TypedefIndex::build(&tu);
+        let filter = StructFilter {
+            name_pattern: Some("_LARGE_INTEGER".into()),
+            header_filter: None,
+            case_sensitive: true,
+        };
+        let unions = collect_unions(&tu, &filter, Some(&idx));
+        let li = unions
+            .iter()
+            .find(|u| u.get_name() == "_LARGE_INTEGER")
+            .ok_or_else(|| anyhow::anyhow!("collect_unions must surface _LARGE_INTEGER"))?;
+        assert_eq!(li.kind(), RecordKind::Union);
+        assert!(
+            li.get_aliases().iter().any(|a| a == "LARGE_INTEGER"),
+            "LARGE_INTEGER alias must be attached, got {:?}",
+            li.get_aliases()
+        );
+
+        Ok(())
+    }
+
+    /// `Union::to_json_full` emits the same `{type, referenced_types}`
+    /// shape as `Struct::to_json_full`.
+    #[test]
+    #[serial]
+    fn union_to_json_full_shape() -> anyhow::Result<()> {
+        winsdk!(clang, index, tu);
+
+        let li = find_union_by_name(&tu, "_LARGE_INTEGER", None)
+            .ok_or_else(|| anyhow::anyhow!("_LARGE_INTEGER must exist"))?;
+        let full = li.to_json_full();
+        assert_eq!(full["type"]["name"], "_LARGE_INTEGER");
+        assert_eq!(full["type"]["kind"], "union");
+        assert!(
+            full["referenced_types"].is_array(),
+            "to_json_full must include referenced_types"
         );
 
         Ok(())
@@ -2407,7 +2750,8 @@ mod tests {
         assert_eq!(j["pointer_depth"], 1);
         assert_eq!(j["underlying_type"], "void");
         assert!(
-            j.get("underlying_record").is_none_or(serde_json::Value::is_null),
+            j.get("underlying_record")
+                .is_none_or(serde_json::Value::is_null),
             "HANDLE should not have underlying_record (void has no record name), got {:?}",
             j["underlying_record"]
         );
@@ -2415,12 +2759,15 @@ mod tests {
         assert_eq!(j["is_function_pointer"], false);
 
         // Struct-typedef shape: inverse.
-        let li = idx.lookup("LARGE_INTEGER").expect("LARGE_INTEGER must exist");
+        let li = idx
+            .lookup("LARGE_INTEGER")
+            .expect("LARGE_INTEGER must exist");
         let j2 = serde_json::to_value(li).expect("Typedef serializes");
         assert_eq!(j2["is_pointer"], false);
         assert_eq!(j2["underlying_record"], "_LARGE_INTEGER");
         assert!(
-            j2.get("underlying_type").is_none_or(serde_json::Value::is_null),
+            j2.get("underlying_type")
+                .is_none_or(serde_json::Value::is_null),
             "LARGE_INTEGER should not have a primitive underlying_type (leaf is a union), got {:?}",
             j2["underlying_type"]
         );
@@ -2461,7 +2808,7 @@ mod tests {
             .ok_or_else(|| anyhow::anyhow!("LPSECURITY_ATTRIBUTES should be a typedef hit"))?;
 
         // The hit's flattened TypeProperties point at the canonical struct.
-        assert_eq!(lp.properties.is_pointer, true);
+        assert!(lp.properties.is_pointer);
         assert_eq!(
             lp.properties.underlying_record.as_deref(),
             Some("_SECURITY_ATTRIBUTES"),

--- a/tui/bb-types-tui/src/data.rs
+++ b/tui/bb-types-tui/src/data.rs
@@ -1,6 +1,6 @@
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashSet};
 
-use bb_clang::{Field, Struct, TypedefIndex};
+use bb_clang::{Field, RecordKind, Struct, TypedefIndex};
 use bb_shared::glob_match;
 use bb_tui::{FileEntry, TuiData, matches_file};
 use ratatui::style::{Color, Modifier, Style};
@@ -8,9 +8,29 @@ use ratatui::text::{Line, Span};
 
 /* ────────────────────────────────── Types ───────────────────────────────── */
 
+/// Maximum depth for inline expansion of nested record types in the TUI.
+/// Matches the JSON `to_json_full` expansion depth in
+/// `crates/bb-clang/src/json.rs` so the TUI shows the same shape the
+/// JSON consumer would see.
+const MAX_DEPTH: usize = 8;
+
+/// Pre-rendered field row data — owned strings, no `Field` lifetime
+/// dependency. Lets us recursively expand nested anonymous records
+/// without juggling self-referential borrows on the TUI state.
+struct RenderedField {
+    prefix: String,
+    connector: &'static str, // "├─" or "╰─"
+    offset_bytes: usize,
+    size: usize,
+    name: Option<String>, // None ⇒ anonymous, name column suppressed
+    type_name: Option<String>,
+    annotation: Option<String>, // dim "(canonical)" chip for typedef'd types
+    anon_chip: Option<&'static str>, // "anonymous union" / "anonymous struct"
+}
+
 enum Row<'a> {
     StructHeader(&'a Struct<'a>),
-    Field { field: &'a Field<'a>, is_last: bool },
+    Field(RenderedField),
     Footer(usize),
     Blank,
 }
@@ -50,7 +70,7 @@ impl TuiData for TypeData<'_> {
     }
 
     fn render_row(&self, index: usize) -> Line<'static> {
-        render_row(&self.rows[index], self.typedef_index)
+        render_row(&self.rows[index])
     }
 
     fn rebuild_index(&mut self, search: Option<&str>) {
@@ -74,9 +94,7 @@ impl TuiData for TypeData<'_> {
             let name_matches = match search {
                 Some(pat) => {
                     glob_match(s.get_name(), pat, false)
-                        || s.get_aliases()
-                            .iter()
-                            .any(|a| glob_match(a, pat, false))
+                        || s.get_aliases().iter().any(|a| glob_match(a, pat, false))
                 }
                 None => true,
             };
@@ -89,12 +107,9 @@ impl TuiData for TypeData<'_> {
 
             let fields = s.get_fields();
             let count = fields.len();
-            for (i, f) in fields.iter().enumerate() {
-                self.rows.push(Row::Field {
-                    field: f,
-                    is_last: i == count - 1,
-                });
-            }
+            let mut seen: HashSet<String> = HashSet::new();
+            seen.insert(s.get_name().to_string());
+            push_fields_recursive(&mut self.rows, fields, "", 0, self.typedef_index, &mut seen);
 
             self.rows.push(Row::Footer(count));
             self.rows.push(Row::Blank);
@@ -102,9 +117,122 @@ impl TuiData for TypeData<'_> {
     }
 }
 
+/* ─────────────────────── Recursive field expansion ──────────────────────── */
+
+/// Walk `fields` and push a row per field. When a field's type is a
+/// record (named or anonymous) with its own fields, recurse up to
+/// [`MAX_DEPTH`] levels. Cycles are broken by `seen`, keyed on the
+/// composite identity (`enclosing_record::field_path` for anonymous,
+/// canonical decl name for named).
+fn push_fields_recursive(
+    rows: &mut Vec<Row<'_>>,
+    fields: &[Field<'_>],
+    prefix: &str,
+    current_depth: usize,
+    typedef_index: &TypedefIndex,
+    seen: &mut HashSet<String>,
+) {
+    let count = fields.len();
+    for (i, f) in fields.iter().enumerate() {
+        let is_last = i == count - 1;
+        let connector: &'static str = if is_last { "╰─" } else { "├─" };
+        rows.push(Row::Field(make_rendered_field(
+            f,
+            prefix.to_string(),
+            connector,
+            typedef_index,
+        )));
+
+        if current_depth >= MAX_DEPTH || !f.has_children() {
+            continue;
+        }
+
+        let type_key = if let Some(aref) = f.get_anon_ref() {
+            Some(aref.identity())
+        } else {
+            f.get_underlying_type()
+                .get_declaration()
+                .and_then(|d| d.get_name())
+        };
+
+        let Some(key) = type_key else {
+            continue;
+        };
+        if !seen.insert(key.clone()) {
+            continue;
+        }
+        let child_fields = f.get_child_fields();
+        if !child_fields.is_empty() {
+            let child_prefix = format!("{prefix}{}", if is_last { "   " } else { "│  " });
+            push_fields_recursive(
+                rows,
+                &child_fields,
+                &child_prefix,
+                current_depth + 1,
+                typedef_index,
+                seen,
+            );
+        }
+        seen.remove(&key);
+    }
+}
+
+/// Build the pre-rendered row payload for one field, resolving the
+/// typedef annotation eagerly so render time has no `TypedefIndex`
+/// dependency.
+fn make_rendered_field(
+    field: &Field,
+    prefix: String,
+    connector: &'static str,
+    typedef_index: &TypedefIndex,
+) -> RenderedField {
+    let type_name = field.get_type_name().map(str::to_string);
+
+    let annotation = type_name.as_deref().and_then(|ty| {
+        bb_clang::display::typedef_annotation(
+            ty,
+            field.get_type_info().underlying_record.as_deref(),
+            Some(typedef_index),
+        )
+    });
+
+    // Anonymous-type chip: when a field's type itself has no name
+    // (the OVERLAPPED anon union case), show "<anonymous union>" or
+    // "<anonymous struct>" in the type column. AnonRef carries the
+    // record kind directly.
+    let anon_chip: Option<&'static str> = if type_name.is_none() {
+        match field.get_anon_ref().map(|r| r.kind) {
+            Some(RecordKind::Union) => Some("union"),
+            Some(RecordKind::Struct) => Some("struct"),
+            None => None,
+        }
+    } else {
+        None
+    };
+
+    // Suppress synthetic `<anonymous_N>` names — only show real C
+    // identifiers.
+    let name = if field.is_anonymous() {
+        None
+    } else {
+        Some(field.get_name().to_string())
+    };
+
+    RenderedField {
+        prefix,
+        connector,
+        offset_bytes: field.get_offset_bytes(),
+        size: field.get_size(),
+        name,
+        type_name,
+        annotation,
+        anon_chip,
+    }
+}
+
 /* ──────────────────────────────── Rendering ─────────────────────────────── */
 
-fn render_row(row: &Row, typedef_index: &TypedefIndex) -> Line<'static> {
+fn render_row(row: &Row) -> Line<'static> {
     match row {
         Row::StructHeader(s) => {
             let mut spans = vec![Span::styled(
@@ -142,55 +270,51 @@ fn render_row(row: &Row, typedef_index: &TypedefIndex) -> Line<'static> {
             Line::from(spans)
         }
 
-        Row::Field { field, is_last } => {
-            let connector = if *is_last {
-                "  \u{2570}\u{2500} "
-            } else {
-                "  \u{251C}\u{2500} "
-            };
-
-            let mut spans = vec![
-                Span::styled(connector.to_string(), Style::default().fg(Color::DarkGray)),
+        Row::Field(rf) => {
+            let mut spans: Vec<Span<'static>> = vec![
+                Span::raw("  "),
+                Span::styled(rf.prefix.clone(), Style::default().fg(Color::DarkGray)),
                 Span::styled(
-                    format!("+0x{:04X}", field.get_offset_bytes()),
+                    format!("{} ", rf.connector),
+                    Style::default().fg(Color::DarkGray),
+                ),
+                Span::styled(
+                    format!("+0x{:04X}", rf.offset_bytes),
                     Style::default().fg(Color::Yellow),
                 ),
                 Span::raw("  "),
-                Span::styled(
-                    field.get_name().to_string(),
+            ];
+
+            if let Some(n) = &rf.name {
+                spans.push(Span::styled(
+                    n.clone(),
                     Style::default()
                         .fg(Color::White)
                         .add_modifier(Modifier::BOLD),
-                ),
-            ];
-
-            if let Some(ty) = field.get_type_name() {
-                spans.push(Span::raw("  "));
-                spans.push(Span::styled(
-                    ty.to_string(),
-                    Style::default().fg(Color::Cyan),
                 ));
+            }
 
-                // Dim `(canonical)` annotation for typedef'd field types
-                // — same logic as the CLI renderer, so HANDLE shows
-                // `(void *)`, LARGE_INTEGER shows `(_LARGE_INTEGER)`, etc.
-                let underlying = field.get_type_info().underlying_record.as_deref();
-                if let Some(canon) = bb_clang::display::typedef_annotation(
-                    ty,
-                    underlying,
-                    Some(typedef_index),
-                ) {
+            if let Some(ty) = &rf.type_name {
+                spans.push(Span::raw("  "));
+                spans.push(Span::styled(ty.clone(), Style::default().fg(Color::Cyan)));
+                if let Some(ann) = &rf.annotation {
                     spans.push(Span::raw(" "));
                     spans.push(Span::styled(
-                        format!("({canon})"),
+                        format!("({ann})"),
                         Style::default().fg(Color::DarkGray),
                     ));
                 }
+            } else if let Some(chip) = rf.anon_chip {
+                spans.push(Span::raw("  "));
+                spans.push(Span::styled(
+                    format!("<anonymous {chip}>"),
+                    Style::default().fg(Color::DarkGray),
+                ));
             }
 
             spans.push(Span::raw("  "));
             spans.push(Span::styled(
-                format!("{} bytes", field.get_size()),
+                format!("{} bytes", rf.size),
                 Style::default().fg(Color::DarkGray),
             ));
 
@@ -216,9 +340,7 @@ fn build_file_index(structs: &[Struct], pattern: Option<&str>) -> Vec<FileEntry>
         let name_matches = match pattern {
             Some(pat) => {
                 glob_match(s.get_name(), pat, false)
-                    || s.get_aliases()
-                        .iter()
-                        .any(|a| glob_match(a, pat, false))
+                    || s.get_aliases().iter().any(|a| glob_match(a, pat, false))
             }
             None => true,
         };

--- a/tui/bb-types-tui/src/data.rs
+++ b/tui/bb-types-tui/src/data.rs
@@ -1,6 +1,6 @@
 use std::collections::BTreeMap;
 
-use bb_clang::{Field, Struct};
+use bb_clang::{Field, Struct, TypedefIndex};
 use bb_shared::glob_match;
 use bb_tui::{FileEntry, TuiData, matches_file};
 use ratatui::style::{Color, Modifier, Style};
@@ -17,14 +17,16 @@ enum Row<'a> {
 
 pub struct TypeData<'a> {
     structs: &'a [Struct<'a>],
+    typedef_index: &'a TypedefIndex,
     rows: Vec<Row<'a>>,
     files: Vec<FileEntry>,
 }
 
 impl<'a> TypeData<'a> {
-    pub fn new(structs: &'a [Struct<'a>]) -> Self {
+    pub fn new(structs: &'a [Struct<'a>], typedef_index: &'a TypedefIndex) -> Self {
         Self {
             structs,
+            typedef_index,
             rows: Vec::new(),
             files: vec![FileEntry {
                 name: "(all)".to_string(),
@@ -48,7 +50,7 @@ impl TuiData for TypeData<'_> {
     }
 
     fn render_row(&self, index: usize) -> Line<'static> {
-        render_row(&self.rows[index])
+        render_row(&self.rows[index], self.typedef_index)
     }
 
     fn rebuild_index(&mut self, search: Option<&str>) {
@@ -66,8 +68,16 @@ impl TuiData for TypeData<'_> {
                 continue;
             }
 
+            // Match the canonical name OR any typedef alias, so the user
+            // can search the TUI by `LARGE_INTEGER` and still find
+            // `_LARGE_INTEGER`.
             let name_matches = match search {
-                Some(pat) => glob_match(s.get_name(), pat, false),
+                Some(pat) => {
+                    glob_match(s.get_name(), pat, false)
+                        || s.get_aliases()
+                            .iter()
+                            .any(|a| glob_match(a, pat, false))
+                }
                 None => true,
             };
 
@@ -94,7 +104,7 @@ impl TuiData for TypeData<'_> {
 
 /* ──────────────────────────────── Rendering ─────────────────────────────── */
 
-fn render_row(row: &Row) -> Line<'static> {
+fn render_row(row: &Row, typedef_index: &TypedefIndex) -> Line<'static> {
     match row {
         Row::StructHeader(s) => {
             let mut spans = vec![Span::styled(
@@ -103,6 +113,15 @@ fn render_row(row: &Row) -> Line<'static> {
                     .fg(Color::Cyan)
                     .add_modifier(Modifier::BOLD),
             )];
+
+            let aliases = s.get_aliases();
+            if !aliases.is_empty() {
+                spans.push(Span::raw("  "));
+                spans.push(Span::styled(
+                    format!("[aka {}]", aliases.join(", ")),
+                    Style::default().fg(Color::DarkGray),
+                ));
+            }
 
             if let Some(size) = s.get_size() {
                 spans.push(Span::raw("  "));
@@ -151,6 +170,22 @@ fn render_row(row: &Row) -> Line<'static> {
                     ty.to_string(),
                     Style::default().fg(Color::Cyan),
                 ));
+
+                // Dim `(canonical)` annotation for typedef'd field types
+                // — same logic as the CLI renderer, so HANDLE shows
+                // `(void *)`, LARGE_INTEGER shows `(_LARGE_INTEGER)`, etc.
+                let underlying = field.get_type_info().underlying_type.as_deref();
+                if let Some(canon) = bb_clang::display::typedef_annotation(
+                    ty,
+                    underlying,
+                    Some(typedef_index),
+                ) {
+                    spans.push(Span::raw(" "));
+                    spans.push(Span::styled(
+                        format!("({canon})"),
+                        Style::default().fg(Color::DarkGray),
+                    ));
+                }
             }
 
             spans.push(Span::raw("  "));
@@ -179,7 +214,12 @@ fn build_file_index(structs: &[Struct], pattern: Option<&str>) -> Vec<FileEntry>
 
     for s in structs {
         let name_matches = match pattern {
-            Some(pat) => glob_match(s.get_name(), pat, false),
+            Some(pat) => {
+                glob_match(s.get_name(), pat, false)
+                    || s.get_aliases()
+                        .iter()
+                        .any(|a| glob_match(a, pat, false))
+            }
             None => true,
         };
 

--- a/tui/bb-types-tui/src/data.rs
+++ b/tui/bb-types-tui/src/data.rs
@@ -174,7 +174,7 @@ fn render_row(row: &Row, typedef_index: &TypedefIndex) -> Line<'static> {
                 // Dim `(canonical)` annotation for typedef'd field types
                 // — same logic as the CLI renderer, so HANDLE shows
                 // `(void *)`, LARGE_INTEGER shows `(_LARGE_INTEGER)`, etc.
-                let underlying = field.get_type_info().underlying_type.as_deref();
+                let underlying = field.get_type_info().underlying_record.as_deref();
                 if let Some(canon) = bb_clang::display::typedef_annotation(
                     ty,
                     underlying,

--- a/tui/bb-types-tui/src/main.rs
+++ b/tui/bb-types-tui/src/main.rs
@@ -1,6 +1,7 @@
 mod data;
 
 use anyhow::Result;
+use bb_clang::TypedefIndex;
 use bb_cli::get_header_config;
 use bb_types_lib::{StructFilter, collect_structs};
 use clang::{Clang, Index};
@@ -51,17 +52,19 @@ fn main() -> Result<()> {
     // Parse headers.
     let tu = config.parse(&index, false)?;
 
+    let typedef_index = TypedefIndex::build(&tu);
+
     let filter = StructFilter {
         name_pattern: args.struct_name.clone(),
         header_filter: args.filter.clone(),
         case_sensitive: args.case_sensitive,
     };
-    let structs = collect_structs(&tu, &filter);
+    let structs = collect_structs(&tu, &filter, Some(&typedef_index));
 
     let initial_search = args.struct_name.as_deref().unwrap_or("");
 
     // Initialize and run the TUI.
-    let data = TypeData::new(&structs);
+    let data = TypeData::new(&structs, &typedef_index);
     let mut app = bb_tui::App::new(data, initial_search);
     bb_tui::event::run(&mut app)?;
 


### PR DESCRIPTION
Closes #14.

Started as typedef-aware lookup (issue #14) and grew into a structural refactor of how `bb-types` represents records. The two pieces are tightly coupled — typedef resolution surfaced LARGE_INTEGER, which is a union, which forced the Struct/Union split — so they ship together.

## Summary

- **Typedef resolution**: `bb-types -s LARGE_INTEGER` hits `_LARGE_INTEGER`, `bb-types -s HANDLE` resolves to `void *`, and `bb-types -s LPSECURITY_ATTRIBUTES` pulls in both the pointer typedef and the `_SECURITY_ATTRIBUTES` struct it points at. Typedef entries flatten the same `TypeProperties` shape that fields and params expose.
- **Struct/Union are now strictly separate types**. `Struct::try_from` rejects `UnionDecl`; named unions like `_LARGE_INTEGER` flow through the parallel `iter_unions` / `collect_unions` / `find_union_by_name`. Both carry `kind: RecordKind` for symmetric JSON dispatch.
- **Anonymous nested records are first-class**. The OVERLAPPED `DUMMYUNIONNAME` pattern (macro expands to empty under default MSVC parsing, leaving the inner union as a sibling `UnionDecl` with no FieldDecl) now produces a synthetic `Field` entry at the right offset, with an `AnonRef { kind, enclosing_record, field_path }` cross-reference into the parent's `referenced_types` slot.
- **JSON shape consolidated** into one `referenced_types` slot per record (replacing `referenced_structs` + `referenced_unions`), with per-entry `"kind"` discriminator. Anonymous entries additionally carry `enclosing_record` + `field_path`.
- **`bb-types` main.rs is now ~100 lines** — `Args`, `main`, `print_display`, `print_json`. Orchestration (collect, auto-expand pointer typedef targets, typedef-hit resolution, suggestion fallback, JSON assembly) lives on `TypeResults` in `bb-types-lib`.
- **TUI** gains recursive depth expansion up to `MAX_DEPTH = 8`, matching the JSON shape.
- **CI** installs WDK via winget so kernel-mode test paths actually run.

## bb-clang additions

- `TypeInfo` is a thin wrapper around serializable `TypeProperties` (raw clang type stays internal). `TypeInfo` derefs to `TypeProperties`, so every existing `info.is_pointer` / `info.pointer_depth` callsite keeps working.
- `underlying_type` is now the **terminal primitive** at the bottom of the canonical chain (`void`, `int`, `unsigned long`, …). `None` when the leaf is a record. New `underlying_record` field carries the record/enum decl name after one level of pointer/array indirection.
- New `TypedefIndex` / `Typedef` / `TypedefKind` (`crates/bb-clang/src/typedef.rs`) walk every `TypedefDecl` once. `TypedefKind::label()` provides human-readable strings for display.
- New `crates/bb-clang/src/record.rs`: `RecordKind` (Struct/Union) + `AnonRef { kind, enclosing_record, field_path }`.
- New `crates/bb-clang/src/union_/mod.rs`: `Union<'a>` mirrors `Struct` but accepts only `UnionDecl`. Both carry `aliases`, `kind`, `extract_nested_records`, `display`, etc.
- `Field::record_kind() -> Option<RecordKind>` for explicit kind dispatch in walkers (no fragile `else if`).
- `Field` gains `is_anonymous`, `anon_ref`, `get_field_decl()` (returns `None` for synthetic anon-record entries). `build_anon_record_field` synthesizes the `Field` for sibling anon decls; `anon_record_offset_in_parent` asks the parent for the offset of any reachable named member (propagates `FieldError::NoOffset` if none exists — no silent zero-offset).
- `collect_fields` uses **two independent per-parent counters** for synthetic `<anonymous_N>` naming: one for nameless `FieldDecl`s, one for sibling record decls. Order-shuffles in clang's child visit can't perturb identities.
- New `display::format_typedef_summary` + `display::render_union` parallel to `render_struct`.
- `is_primitive_kind` / `is_array_kind` / `is_function_pointer` are the single source of truth across `type_info.rs` and `typedef::classify` (via match-guard syntax).
- `records_to_json_full(structs, unions) -> Value` produces the shared `{ types, referenced_types }` envelope. Re-exported from `bb_clang::lib`.

## bb-types refactor

- `collect_structs` / `collect_unions` match name pattern against canonical name **and** every typedef alias. `find_struct_by_name` / `find_union_by_name` resolve canonical decl name to a fully-built record with aliases.
- Auto-expansion: when a search surfaces a typedef hit whose `underlying_record` names a struct/union not already in the result set, pull it in.
- New `TypeResults<'tu, 'idx>` in `bb-types-lib` holds the full query result and exposes `is_empty`, `to_json_value(command)`, `records_as_json_rows()`, `typedefs_as_json_rows()`, `format_display(...)`. `collect_results(tu, filter, idx)` runs the whole pipeline.
- `suggest_alternatives(tu, idx, pattern)` is the no-results fallback.
- main.rs reduced to argument parsing + dispatching to lib helpers.

## JSON shape

```jsonc
// bb-types -s _OVERLAPPED --json
{
  "command": "...",
  "types": [
    { "name": "_OVERLAPPED", "kind": "struct", "aliases": ["OVERLAPPED", "LPOVERLAPPED"],
      "fields": [
        { "name": "Internal", "type": "ULONG_PTR", "underlying_type": "unsigned __int64", ... },
        { "name": "InternalHigh", ... },
        { "name": "<anonymous_0>", "is_anonymous": true, "type": null,
          "anon_ref": { "kind": "union", "enclosing_record": "_OVERLAPPED",
                        "field_path": ["<anonymous_0>"] }, ... },
        { "name": "hEvent", "type": "HANDLE", "is_pointer": true, "underlying_type": "void", ... }
      ] }
  ],
  "referenced_types": [
    { "name": "<anonymous_0>", "kind": "union", "is_anonymous": true,
      "enclosing_record": "_OVERLAPPED", "field_path": ["<anonymous_0>"],
      "fields": [
        { "name": "<anonymous_0>", "is_anonymous": true,
          "anon_ref": { ..., "field_path": ["<anonymous_0>", "<anonymous_0>"] }, ... },
        { "name": "Pointer", "type": "PVOID", ... }
      ] },
    { "name": "<anonymous_0>", "kind": "struct", "is_anonymous": true,
      "enclosing_record": "_OVERLAPPED", "field_path": ["<anonymous_0>", "<anonymous_0>"],
      "fields": [
        { "name": "Offset", "type": "DWORD", ... },
        { "name": "OffsetHigh", "type": "DWORD", ... }
      ] }
  ],
  "typedefs": [ ... ]
}
```

Cross-reference key for anonymous entries is `(enclosing_record, field_path)`. The synthetic `<anonymous_N>` names use angle brackets so they can never collide with real C identifiers.

`chain.first()` is the immediate alias target; `chain.last()` equals `canonical`.

## CI

Adds a winget step that installs `Microsoft.WindowsWDK.10.0.22621` before tests run, so the `windows-latest` runner can actually parse kernel-mode headers (km/ntddk.h and friends). Verifies the install by globbing for ntddk.h; fails loud rather than letting kernel-mode tests silently skip.

## Test plan

- [x] `cargo test --package bb-tests` — **97 passed**, 0 failed, 1 ignored.
- [x] `bb-types -s _OVERLAPPED` renders all 4 slots (Internal, InternalHigh, synthetic anon union, hEvent) at the correct offsets.
- [x] `bb-types -s _OVERLAPPED --depth 2` recursively expands the nested anon struct (Offset, OffsetHigh).
- [x] `bb-types -s LARGE_INTEGER` resolves to `_LARGE_INTEGER` (a union) with `[aka LARGE_INTEGER]` chip.
- [x] `bb-types -s HANDLE --json` returns typedef entry with `is_pointer: true`, `pointer_depth: 1`, `underlying_type: "void"`.
- [x] `bb-types -s LPSECURITY_ATTRIBUTES --json` auto-pulls `_SECURITY_ATTRIBUTES` into `types[]`.
- [x] `bb-types -s _OVERLAPPED --json` produces a single `referenced_types` array with both the anon union and its nested anon struct, distinguished by `kind`.
- [x] `_OVERLAPPED.get_fields()` length is exactly 4; synthetic anon entry has non-zero offset 16 (regression test for the offset-fallback bug from review).
- [x] `bb-funcs -n CloseHandle` annotates the HANDLE param as `HANDLE (void *)` and the return as `BOOL (int)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
